### PR TITLE
Move colour bar row above date row for Vivaldi page

### DIFF
--- a/componist/antonio-vivaldi/index.html
+++ b/componist/antonio-vivaldi/index.html
@@ -850,6 +850,9 @@ time.uagb-post__date {
 <div class="js-wpv-view-layout js-wpv-layout-responsive js-wpv-view-layout-98-CPID2645" data-pagination='{"id":98,"query":"normal","type":"disabled","effect":"fade","duration":"500","speed":5,"pause_on_hover":"disabled","stop_rollover":"false","cache_pages":"enabled","preload_images":"enabled","preload_pages":"enabled","preload_reach":"1","spinner":"builtin","spinner_image":"https://stabatmater.info/wp-content/plugins/wp-views/embedded/res/img/ajax-loader.gif","callback_next":"","manage_history":"enabled","has_controls_in_form":"disabled","infinite_tolerance":"0","max_pages":0,"page":1,"base_permalink":"/componist/antonio-vivaldi/?wpv_view_count=98-CPID2645&amp;wpv_paged=WPV_PAGE_NUM","loop":{"type":"","name":"","data":[],"id":0}}' data-permalink="/componist/antonio-vivaldi/?wpv_view_count=98-CPID2645" data-viewnumber="98-CPID2645" id="wpv-view-layout-98-CPID2645">
 <h2>About the Stabat Mater</h2>
 <table border="0" celpadding="0" class="stabatmater" width="100%">
+<tr><td><strong>Colour bar</strong>:</td><td>
+<p><img alt="vivaldi" class="alignleft size-full wp-image-1958" decoding="async" height="152" src="../../assets/4d5ba0df63b525135bb66bc13f728664277a2fc255002296c414c6edc0caaf9b.gif" width="549"/></p>
+</td></tr>
 <tr><td width="20%"><strong>Date</strong>: </td><td>ca. 1727</td></tr>
 <tr><td><strong>Performers</strong>:</td><td> <p>Alto, strings and continuo</p>
 </td></tr>
@@ -857,9 +860,6 @@ time.uagb-post__date {
 <tr><td><strong>Particulars</strong>: </td><td><p>The composition is divided into eight sections. The melodies of sections 1 to 3 are repeated in sections 4 to 6. For me, this Stabat Mater is one of the most beautiful ever composed. The singers in the first two registrations that I possess differ greatly with respect to their voices, but both sing marvelous. You should hear them both!</p>
 </td></tr>
 <tr><td><strong>Textual variations</strong>:</td><td><p>Only the first ten stanzas are used. It seems that for some time shorter versions of the Stabat Mater were used as a hymn for Vespers for the Friday after Holy Week</p>
-</td></tr>
-<tr><td><strong>Colour bar</strong>:</td><td>
-<p><img alt="vivaldi" class="alignleft size-full wp-image-1958" decoding="async" height="152" src="../../assets/4d5ba0df63b525135bb66bc13f728664277a2fc255002296c414c6edc0caaf9b.gif" width="549"/></p>
 </td></tr></table>
 <h2>Information about the recording</h2>
 <div class="js-wpv-view-layout js-wpv-layout-responsive js-wpv-view-layout-97-CPID2646" data-pagination='{"id":97,"query":"normal","type":"disabled","effect":"fade","duration":"500","speed":5,"pause_on_hover":"disabled","stop_rollover":"false","cache_pages":"enabled","preload_images":"enabled","preload_pages":"enabled","preload_reach":"1","spinner":"builtin","spinner_image":"https://stabatmater.info/wp-content/plugins/wp-views/embedded/res/img/ajax-loader.gif","callback_next":"","manage_history":"enabled","has_controls_in_form":"disabled","infinite_tolerance":"0","max_pages":0,"page":1,"base_permalink":"/componist/antonio-vivaldi/?wpv_view_count=97-CPID2646&amp;wpv_paged=WPV_PAGE_NUM","loop":{"type":"","name":"","data":[],"id":0}}' data-permalink="/componist/antonio-vivaldi/?wpv_view_count=97-CPID2646" data-viewnumber="97-CPID2646" id="wpv-view-layout-97-CPID2646">


### PR DESCRIPTION
## Summary
- reorder the "About the Stabat Mater" table on the Antonio Vivaldi page so the colour bar appears as the first row before the date information

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d151b6c3f88333a56e3dba5ceabdb5