### PR TITLE
Add donation outage notice to recent posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -862,6 +862,10 @@ time.uagb-post__date {
 <h3 class="widgettitle widget-title">Recent posts</h3>
 <ul>
 <li>
+<a href="stabat-mater-collection-support/index.html">Donations temporarily unavailable due to technical issues &ndash; thank you for your patience</a>
+<span class="post-date">20-04-2025</span>
+</li>
+<li>
 <a href="a-unique-approach-to-pergolesis-stabat-mater/index.html">A Unique Approach to Pergolesi&rsquo;s Stabat Mater</a>
 <span class="post-date">13-04-2025</span>
 </li>


### PR DESCRIPTION
## Summary
- add a recent post entry informing visitors that donations are temporarily unavailable

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d155c61bf08333bc9b626c5c79fe10