### PR TITLE
Add donations downtime article and update recent posts

### DIFF
--- a/donations-temporarily-unavailable/index.html
+++ b/donations-temporarily-unavailable/index.html
@@ -7,30 +7,37 @@
 <meta content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" name="robots"/>
 <style>img:is([sizes="auto" i], [sizes^="auto," i]) { contain-intrinsic-size: 3000px 1500px }</style>
 <!-- This site is optimized with the Yoast SEO plugin v25.7 - https://yoast.com/wordpress/plugins/seo/ -->
-<title>Stabat Mater Collection: compositions, composers, texts and translations</title>
-<meta content="Search our Stabat Mater Collection: 300 compositions, composers, texts and 24 translations of the original Latin poem Stabat Mater Dolorosa." name="description"/>
-<link href="https://stabatmater.info/" rel="canonical"/>
+<title>Donations temporarily unavailable - The ultimate Stabat Mater site</title>
+<meta content="Our donation form is temporarily offline while we upgrade payment processing—learn how you can continue supporting the Stabat Mater collection." name="description"/>
+<link href="https://stabatmater.info/donations-temporarily-unavailable/" rel="canonical"/>
 <meta content="en_US" property="og:locale"/>
-<meta content="website" property="og:type"/>
-<meta content="Stabat Mater Collection: compositions, composers, texts and translations" property="og:title"/>
-<meta content="Search our Stabat Mater Collection: 300 compositions, composers, texts and 24 translations of the original Latin poem Stabat Mater Dolorosa." property="og:description"/>
-<meta content="https://stabatmater.info/" property="og:url"/>
+<meta content="article" property="og:type"/>
+<meta content="Donations temporarily unavailable - The ultimate Stabat Mater site" property="og:title"/>
+<meta content="Our donation form is temporarily offline while we upgrade payment processing—learn how you can continue supporting the Stabat Mater collection." property="og:description"/>
+<meta content="https://stabatmater.info/donations-temporarily-unavailable/" property="og:url"/>
 <meta content="The ultimate Stabat Mater site" property="og:site_name"/>
-<meta content="2025-04-20T14:14:09+00:00" property="article:modified_time"/>
-<script class="yoast-schema-graph" type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"WebPage","@id":"https://stabatmater.info/","url":"https://stabatmater.info/","name":"Stabat Mater Collection: compositions, composers, texts and translations","isPartOf":{"@id":"https://stabatmater.info/#website"},"about":{"@id":"https://stabatmater.info/#organization"},"datePublished":"2015-02-10T11:18:22+00:00","dateModified":"2025-04-20T14:14:09+00:00","description":"Search our Stabat Mater Collection: 300 compositions, composers, texts and 24 translations of the original Latin poem Stabat Mater Dolorosa.","breadcrumb":{"@id":"https://stabatmater.info/#breadcrumb"},"inLanguage":"en-US","potentialAction":[{"@type":"ReadAction","target":["https://stabatmater.info/"]}]},{"@type":"BreadcrumbList","@id":"https://stabatmater.info/#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"name":"Home"}]},{"@type":"WebSite","@id":"https://stabatmater.info/#website","url":"https://stabatmater.info/","name":"The ultimate Stabat Mater site","description":"a musical journey through the ages...","publisher":{"@id":"https://stabatmater.info/#organization"},"potentialAction":[{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://stabatmater.info/?s={search_term_string}"},"query-input":{"@type":"PropertyValueSpecification","valueRequired":true,"valueName":"search_term_string"}}],"inLanguage":"en-US"},{"@type":"Organization","@id":"https://stabatmater.info/#organization","name":"The ultimate Stabat Mater site","url":"https://stabatmater.info/","logo":{"@type":"ImageObject","inLanguage":"en-US","@id":"https://stabatmater.info/#/schema/logo/image/","url":"https://stabatmater.info/wp-content/uploads/2021/02/cropped-cropped-stabat-mater-beeld.png","contentUrl":"https://stabatmater.info/wp-content/uploads/2021/02/cropped-cropped-stabat-mater-beeld.png","width":984,"height":1200,"caption":"The ultimate Stabat Mater site"},"image":{"@id":"https://stabatmater.info/#/schema/logo/image/"}}]}</script>
+<meta content="2025-04-20T08:30:00+00:00" property="article:published_time"/>
+<meta content="2025-04-20T08:30:00+00:00" property="article:modified_time"/>
+<meta content="https://stabatmater.info/wp-content/uploads/2024/10/Stabat-adv-collect_nw.png" property="og:image"/>
+<meta content="Hannie Van Osnabrugge" name="author"/>
+<meta content="Written by" name="twitter:label1"/>
+<meta content="Hannie Van Osnabrugge" name="twitter:data1"/>
+<meta content="Est. reading time" name="twitter:label2"/>
+<meta content="1 minute" name="twitter:data2"/>
+<script class="yoast-schema-graph" type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Article","@id":"https://stabatmater.info/donations-temporarily-unavailable/#article","isPartOf":{"@id":"https://stabatmater.info/donations-temporarily-unavailable/"},"author":{"name":"Hannie Van Osnabrugge","@id":"https://stabatmater.info/#/schema/person/c20f0e48c9d8e94e40cef24821a4dc6c"},"headline":"Donations temporarily unavailable","datePublished":"2025-04-20T08:30:00+00:00","dateModified":"2025-04-20T08:30:00+00:00","mainEntityOfPage":{"@id":"https://stabatmater.info/donations-temporarily-unavailable/"},"wordCount":116,"commentCount":0,"publisher":{"@id":"https://stabatmater.info/#organization"},"image":{"@id":"https://stabatmater.info/donations-temporarily-unavailable/#primaryimage"},"thumbnailUrl":"https://stabatmater.info/wp-content/uploads/2024/10/Stabat-adv-collect_nw.png","articleSection":["Stabat Mater"],"inLanguage":"en-US","potentialAction":[{"@type":"CommentAction","name":"Comment","target":["https://stabatmater.info/donations-temporarily-unavailable/#respond"]}]},{"@type":"WebPage","@id":"https://stabatmater.info/donations-temporarily-unavailable/","url":"https://stabatmater.info/donations-temporarily-unavailable/","name":"Donations temporarily unavailable - The ultimate Stabat Mater site","isPartOf":{"@id":"https://stabatmater.info/#website"},"primaryImageOfPage":{"@id":"https://stabatmater.info/donations-temporarily-unavailable/#primaryimage"},"image":{"@id":"https://stabatmater.info/donations-temporarily-unavailable/#primaryimage"},"thumbnailUrl":"https://stabatmater.info/wp-content/uploads/2024/10/Stabat-adv-collect_nw.png","datePublished":"2025-04-20T08:30:00+00:00","dateModified":"2025-04-20T08:30:00+00:00","description":"Our donation form is temporarily offline while we upgrade payment processing\u2014learn how you can continue supporting the Stabat Mater collection.","breadcrumb":{"@id":"https://stabatmater.info/donations-temporarily-unavailable/#breadcrumb"},"inLanguage":"en-US","potentialAction":[{"@type":"ReadAction","target":["https://stabatmater.info/donations-temporarily-unavailable/"]}]},{"@type":"ImageObject","inLanguage":"en-US","@id":"https://stabatmater.info/donations-temporarily-unavailable/#primaryimage","url":"https://stabatmater.info/wp-content/uploads/2024/10/Stabat-adv-collect_nw.png","contentUrl":"https://stabatmater.info/wp-content/uploads/2024/10/Stabat-adv-collect_nw.png","width":940,"height":549},{"@type":"BreadcrumbList","@id":"https://stabatmater.info/donations-temporarily-unavailable/#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://stabatmater.info/"},{"@type":"ListItem","position":2,"name":"Donations temporarily unavailable"}]},{"@type":"WebSite","@id":"https://stabatmater.info/#website","url":"https://stabatmater.info/","name":"The ultimate Stabat Mater site","description":"a musical journey through the ages...","publisher":{"@id":"https://stabatmater.info/#organization"},"potentialAction":[{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://stabatmater.info/?s={search_term_string}"},"query-input":{"@type":"PropertyValueSpecification","valueRequired":true,"valueName":"search_term_string"}}],"inLanguage":"en-US"},{"@type":"Organization","@id":"https://stabatmater.info/#organization","name":"The ultimate Stabat Mater site","url":"https://stabatmater.info/","logo":{"@type":"ImageObject","inLanguage":"en-US","@id":"https://stabatmater.info/#/schema/logo/image/","url":"https://stabatmater.info/wp-content/uploads/2021/02/cropped-cropped-stabat-mater-beeld.png","contentUrl":"https://stabatmater.info/wp-content/uploads/2021/02/cropped-cropped-stabat-mater-beeld.png","width":984,"height":1200,"caption":"The ultimate Stabat Mater site"},"image":{"@id":"https://stabatmater.info/#/schema/logo/image/"}},{"@type":"Person","@id":"https://stabatmater.info/#/schema/person/c20f0e48c9d8e94e40cef24821a4dc6c","name":"Hannie Van Osnabrugge","image":{"@type":"ImageObject","inLanguage":"en-US","@id":"https://stabatmater.info/#/schema/person/image/","url":"https://secure.gravatar.com/avatar/e6c5eae59d08c051a651ed5a0e0e18715382ee18bdacbd7f397da0f99c40b704?s=96&d=mm&r=g","contentUrl":"https://secure.gravatar.com/avatar/e6c5eae59d08c051a651ed5a0e0e18715382ee18bdacbd7f397da0f99c40b704?s=96&d=mm&r=g","caption":"Hannie Van Osnabrugge"},"url":"https://stabatmater.info/author/johanna/"}]}</script>
 <!-- / Yoast SEO plugin. -->
 <link href="//fonts.googleapis.com" rel="dns-prefetch"/>
 <link href="https://stabatmater.info/feed/" rel="alternate" title="The ultimate Stabat Mater site &raquo; Feed" type="application/rss+xml"/>
 <link href="https://stabatmater.info/comments/feed/" rel="alternate" title="The ultimate Stabat Mater site &raquo; Comments Feed" type="application/rss+xml"/>
 <link href="https://stabatmater.info/events/?ical=1" rel="alternate" title="The ultimate Stabat Mater site &raquo; iCal Feed" type="text/calendar"/>
-<link href="https://stabatmater.info/stabat-mater-collection/feed/" rel="alternate" title="The ultimate Stabat Mater site &raquo; Explore the Timeless Legacy of the Stabat Mater Comments Feed" type="application/rss+xml"/>
+<link href="https://stabatmater.info/donations-temporarily-unavailable/feed/" rel="alternate" title="The ultimate Stabat Mater site &raquo; Donations temporarily unavailable Comments Feed" type="application/rss+xml"/>
 <!-- This site uses the Google Analytics by MonsterInsights plugin v9.7.0 - Using Analytics tracking - https://www.monsterinsights.com/ -->
 <script async="" data-cfasync="false" data-wpfc-render="false" src="https://www.googletagmanager.com/gtag/js?id=G-P3H9YYP0G1" type="text/javascript"></script>
 <script data-cfasync="false" data-wpfc-render="false" type="text/javascript">
 				var mi_version = '9.7.0';
 				var mi_track_user = true;
 				var mi_no_track_reason = '';
-								var MonsterInsightsDefaultLocations = {"page_location":"https:\/\/stabatmater.info\/"};
+								var MonsterInsightsDefaultLocations = {"page_location":"https:\/\/stabatmater.info\/donations-temporarily-unavailable\/"};
 								if ( typeof MonsterInsightsPrivacyGuardFilter === 'function' ) {
 					var MonsterInsightsLocations = (typeof MonsterInsightsExcludeQuery === 'object') ? MonsterInsightsPrivacyGuardFilter( MonsterInsightsExcludeQuery ) : MonsterInsightsPrivacyGuardFilter( MonsterInsightsDefaultLocations );
 				} else {
@@ -248,8 +255,8 @@ window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/16
 !function(s,n){var o,i,e;function c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),a=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return t.every(function(e,t){return e===a[t]})}function u(e,t){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);for(var n=e.getImageData(16,16,1,1),a=0;a<n.data.length;a++)if(0!==n.data[a])return!1;return!0}function f(e,t,n,a){switch(t){case"flag":return n(e,"\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f","\ud83c\udff3\ufe0f\u200b\u26a7\ufe0f")?!1:!n(e,"\ud83c\udde8\ud83c\uddf6","\ud83c\udde8\u200b\ud83c\uddf6")&&!n(e,"\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f","\ud83c\udff4\u200b\udb40\udc67\u200b\udb40\udc62\u200b\udb40\udc65\u200b\udb40\udc6e\u200b\udb40\udc67\u200b\udb40\udc7f");case"emoji":return!a(e,"\ud83e\udedf")}return!1}function g(e,t,n,a){var r="undefined"!=typeof WorkerGlobalScope&&self instanceof WorkerGlobalScope?new OffscreenCanvas(300,150):s.createElement("canvas"),o=r.getContext("2d",{willReadFrequently:!0}),i=(o.textBaseline="top",o.font="600 32px Arial",{});return e.forEach(function(e){i[e]=t(o,e,n,a)}),i}function t(e){var t=s.createElement("script");t.src=e,t.defer=!0,s.head.appendChild(t)}"undefined"!=typeof Promise&&(o="wpEmojiSettingsSupports",i=["flag","emoji"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){s.addEventListener("DOMContentLoaded",e,{once:!0})}),new Promise(function(t){var n=function(){try{var e=JSON.parse(sessionStorage.getItem(o));if("object"==typeof e&&"number"==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&"object"==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if("undefined"!=typeof Worker&&"undefined"!=typeof OffscreenCanvas&&"undefined"!=typeof URL&&URL.createObjectURL&&"undefined"!=typeof Blob)try{var e="postMessage("+g.toString()+"("+[JSON.stringify(i),f.toString(),p.toString(),u.toString()].join(",")+"));",a=new Blob([e],{type:"text/javascript"}),r=new Worker(URL.createObjectURL(a),{name:"wpTestEmojiSupports"});return void(r.onmessage=function(e){c(n=e.data),r.terminate(),t(n)})}catch(e){}c(n=g(i,f,p,u))}t(n)}).then(function(e){for(var t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],"flag"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);
 /* ]]> */
 </script>
-<link href="assets/774d3003b5549c4f934fb09c2e56f3a092ba02054d8c2b5944371891802b6fd7.css" id="genesis-blocks-style-css-css" media="all" rel="stylesheet" type="text/css"/>
-<link href="assets/f31780b817103b5f627f41bc9044e890f34d3855e0f55002052593a44f608012.css" id="sbi_styles-css" media="all" rel="stylesheet" type="text/css"/>
+<link href="../assets/774d3003b5549c4f934fb09c2e56f3a092ba02054d8c2b5944371891802b6fd7.css" id="genesis-blocks-style-css-css" media="all" rel="stylesheet" type="text/css"/>
+<link href="../assets/f31780b817103b5f627f41bc9044e890f34d3855e0f55002052593a44f608012.css" id="sbi_styles-css" media="all" rel="stylesheet" type="text/css"/>
 <style id="wp-emoji-styles-inline-css" type="text/css">
 
 	img.wp-smiley, img.emoji {
@@ -264,7 +271,7 @@ window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/16
 		padding: 0 !important;
 	}
 </style>
-<link href="assets/896dc133320281a35fe566abcf02ea0c83bcbbd1e03847a29c9dff1e03c1be47.css" id="wp-block-library-css" media="all" rel="stylesheet" type="text/css"/>
+<link href="../assets/896dc133320281a35fe566abcf02ea0c83bcbbd1e03847a29c9dff1e03c1be47.css" id="wp-block-library-css" media="all" rel="stylesheet" type="text/css"/>
 <style id="classic-theme-styles-inline-css" type="text/css">
 /*! This file is auto-generated */
 .wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}
@@ -273,10 +280,10 @@ window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/16
 .dashicons{font-family:dashicons!important}.wp-block-ilb-icon-list{text-align:center}.wp-block-ilb-icon-list *{box-sizing:border-box}.wp-block-ilb-icon-list .ilbIconList{background:transparent;box-shadow:0 0 10px 0 rgba(69,39,164,.502);display:inline-block;max-width:100%;padding:30px 25px}.wp-block-ilb-icon-list .ilbIconList.left .header{justify-items:start}.wp-block-ilb-icon-list .ilbIconList.center{text-align:center}.wp-block-ilb-icon-list .ilbIconList.center .header{justify-items:center}.wp-block-ilb-icon-list .ilbIconList.center ul.lists{display:inline-block}.wp-block-ilb-icon-list .ilbIconList.right .header{justify-items:end}.wp-block-ilb-icon-list .ilbIconList.right ul.lists .list{flex-direction:row-reverse}.wp-block-ilb-icon-list .ilbIconList .header{display:grid;height:-moz-min-content;height:min-content;margin-bottom:30px}.wp-block-ilb-icon-list .ilbIconList .header .description,.wp-block-ilb-icon-list .ilbIconList .header .title{margin:0 0 5px;text-align:initial;width:auto}.wp-block-ilb-icon-list .ilbIconList .header .title{color:#4527a4;font-size:30px;font-weight:700;text-transform:uppercase}.wp-block-ilb-icon-list .ilbIconList .header .description{color:#828282;font-size:18px;font-weight:500}.wp-block-ilb-icon-list .ilbIconList .header .separator{border-top:2px solid #828282;display:inline-block;text-align:initial;width:20%}.wp-block-ilb-icon-list .ilbIconList ul.lists{list-style-type:none;margin:0;padding:0}.wp-block-ilb-icon-list .ilbIconList ul.lists .link{text-decoration:none}.wp-block-ilb-icon-list .ilbIconList ul.lists .link li.list{padding-bottom:7px}.wp-block-ilb-icon-list .ilbIconList ul.default{list-style-type:none;margin:0;padding:0}.wp-block-ilb-icon-list .ilbIconList ul.default .content{max-width:90%;padding:10px}.wp-block-ilb-icon-list .ilbIconList ul.default li{align-items:center;display:flex;gap:15px;padding:0}.wp-block-ilb-icon-list .ilbIconList ul.default li:not(:last-child){margin-bottom:8px}.wp-block-ilb-icon-list .ilbIconList ul.default li .icon{align-items:center;background:#4527a4;border-radius:50%;color:#fff;display:flex;font-size:18px;font-style:normal;height:30px;justify-content:center;width:30px}.wp-block-ilb-icon-list .ilbIconList ul.default li .link{display:inline-block;text-decoration:none}.wp-block-ilb-icon-list .ilbIconList ul.default li .text{color:#828282;margin:0;max-width:calc(100% - 45px);text-align:left}.wp-block-ilb-icon-list .ilbIconList ul.default li .text a{color:inherit;font-size:inherit;text-decoration:inherit}.wp-block-ilb-icon-list .ilbIconList ul.default li .text a:hover{color:inherit}.wp-block-ilb-icon-list .ilbIconList ul.theme2 .link{text-decoration:none}.wp-block-ilb-icon-list .ilbIconList ul.theme2 .link li.list{margin-bottom:15px}.wp-block-ilb-icon-list .ilbIconList ul.theme2 li{align-items:center;border-radius:12px;box-shadow:0 0 6px rgba(0,0,0,.2);cursor:pointer;display:flex;margin-bottom:15px;padding:16px;transition:background-color .2s ease}.wp-block-ilb-icon-list .ilbIconList ul.theme2 li:last-child{margin-bottom:0}.wp-block-ilb-icon-list .ilbIconList ul.theme2 li:hover{background-color:rgba(0,0,0,.02)}.wp-block-ilb-icon-list .ilbIconList ul.theme2 li .icon{align-items:center;border-radius:50%;display:flex;justify-content:center}.wp-block-ilb-icon-list .ilbIconList ul.theme2 li .content{flex:1;margin-left:18px;max-width:90%;padding:10px;text-align:left}.wp-block-ilb-icon-list .ilbIconList ul.theme2 li .content h3{font-family:sans-serif;font-size:22px;font-weight:500}.wp-block-ilb-icon-list .ilbIconList ul.theme2 li .content p{font-size:14px;margin-top:-15px}.wp-block-ilb-icon-list .ilbIconList ul.theme2 li .arrow{color:#ccc;margin-left:16px}.wp-block-ilb-icon-list .ilbIconList ul.theme3{display:grid}.wp-block-ilb-icon-list .ilbIconList ul.theme3 .list{box-sizing:border-box;cursor:pointer;padding:15px 10px;transition:all .4s cubic-bezier(.25,.8,.25,1);word-wrap:break-word;white-space:normal}.wp-block-ilb-icon-list .ilbIconList ul.theme3 .list .feature-container .feature .icon-wrapper{transition:transform .5s ease}.wp-block-ilb-icon-list .ilbIconList ul.theme3 .list .feature-container:hover .feature .icon-wrapper{transform:rotate(45deg)}.wp-block-ilb-icon-list .ilbIconList ul.theme3 .list:hover{background-color:#eaecee;box-shadow:0 12px 25px rgba(0,0,0,.3);transform:translateY(-8px)}.wp-block-ilb-icon-list .ilbIconList ul.theme3 .link,.wp-block-ilb-icon-list .ilbIconList ul.theme4 .link{text-decoration:none}.wp-block-ilb-icon-list .ilbIconList ul.theme4 .link li.list{margin-bottom:15px}.wp-block-ilb-icon-list .ilbIconList ul.theme4 li{align-items:center;border-radius:12px;box-shadow:0 0 6px rgba(0,0,0,.2);cursor:pointer;display:flex;margin-bottom:15px;padding:25px;position:relative;transition:background-color .2s ease}.wp-block-ilb-icon-list .ilbIconList ul.theme4 li:last-child{margin-bottom:0}.wp-block-ilb-icon-list .ilbIconList ul.theme4 li:hover{background-color:rgba(0,0,0,.02)}.wp-block-ilb-icon-list .ilbIconList ul.theme4 li .icon{align-items:center;border-radius:50%;display:flex;justify-content:center}.wp-block-ilb-icon-list .ilbIconList ul.theme4 li .content{flex:1;margin-left:15px;margin-top:20px;max-width:90%;padding:10px;text-align:left}.wp-block-ilb-icon-list .ilbIconList ul.theme4 li .content h3{font-family:sans-serif;font-size:22px;font-weight:500}.wp-block-ilb-icon-list .ilbIconList ul.theme4 li .content p{font-size:14px;margin-top:-15px}.wp-block-ilb-icon-list .ilbIconList ul.theme4 li .arrow{color:#ccc;margin-left:16px}.wp-block-ilb-icon-list .ilbIconList ul.theme4 li .hidden-badge{display:none}.wp-block-ilb-icon-list .ilbIconList ul.theme4 li .badge{border-radius:7px;padding:5px 8px;position:absolute;right:20px;top:0}.wp-block-ilb-icon-list .ilbIconList ul.theme5{display:grid}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .link{text-decoration:none}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .content{max-width:90%;padding:10px}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .icon-card-wrapper{position:relative;transition:transform .3s ease}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .icon-card-wrapper:hover{transform:translateY(-4px)}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .bg-element{border-radius:1rem;inset:0;position:absolute;transition:transform .3s ease}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .bg-element-1{transform:rotate(3deg)}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .bg-element-2{transform:rotate(-3deg)}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .icon-card-wrapper:hover .bg-element-1{transform:rotate(6deg)}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .icon-card-wrapper:hover .bg-element-2{transform:rotate(-6deg)}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .icon-card{border:1px solid #e5e7eb;border-radius:1rem;box-shadow:0 10px 15px -3px rgba(0,0,0,.1);padding:1.5rem;position:relative;transition:all .3s ease}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .icon-card:hover{box-shadow:0 20px 25px -5px rgba(0,0,0,.1)}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .icon-container{margin-bottom:1.5rem;position:relative}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .icon-bg-blur{border-radius:50%;filter:blur(20px);inset:0;opacity:.2;position:absolute;transition:opacity .3s ease}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .icon-card:hover .icon-bg-blur{opacity:.3}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .icon-wrapper{align-items:center;display:flex;justify-content:center;margin:0 auto;position:relative}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .icon-pulse{animation:pulse 2s infinite;border-radius:50%;inset:0;position:absolute}@keyframes pulse{0%{opacity:.5;transform:scale(.95)}50%{opacity:.8;transform:scale(1.05)}to{opacity:.5;transform:scale(.95)}}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .icon-circle{align-items:center;border-radius:50%;display:inline-flex;justify-content:center;position:relative;transition:transform .3s ease}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .icon-card:hover .icon-circle{transform:scale(1.1)}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .icon{color:#4f46e5;height:2rem;width:2rem}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .card-content{text-align:center}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .card-title{margin-bottom:.5rem;transition:color .3s ease}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .icon-card:hover .card-title{color:#4f46e5}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .card-description{line-height:1.5;transition:color .3s ease}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .icon-card:hover .card-description{color:#374151}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .animated-border{background:linear-gradient(90deg,#3b82f6,#8b5cf6);bottom:0;height:2px;left:50%;position:absolute;transform:translateX(-50%);transition:width .5s ease;width:0}.wp-block-ilb-icon-list .ilbIconList ul.theme5 .icon-card:hover .animated-border{width:80%}.wp-block-ilb-icon-list .ilbIconList ul.theme6 .icon-list-container{background:#fff;border-radius:.5rem;box-shadow:0 4px 6px rgba(0,0,0,.1);margin:0 auto;overflow:hidden;width:100%}.wp-block-ilb-icon-list .ilbIconList ul.theme6 .icon-table{border-collapse:collapse;text-align:center;width:100%}.wp-block-ilb-icon-list .ilbIconList ul.theme6 .icon-table td{border-bottom:1px solid #e5e7eb;padding:1rem}.wp-block-ilb-icon-list .ilbIconList ul.theme6 .icon-container{align-items:center;display:flex;justify-content:center}.wp-block-ilb-icon-list .ilbIconList ul.theme6 .try-button{border:none;border-radius:.375rem;cursor:pointer;padding:6px 10px;transition:background-color .2s;width:70px}.wp-block-ilb-icon-list .ilbIconList ul.theme6 .try-button:hover{background-color:#059669}.wp-block-ilb-icon-list .ilbIconList ul.theme7{display:grid}.wp-block-ilb-icon-list .ilbIconList ul.theme7 .icon-list-satellite{position:relative}.wp-block-ilb-icon-list .ilbIconList ul.theme7 .glass-card{border:1px solid #e5e7eb;border-radius:1rem;box-shadow:0 10px 15px -3px rgba(0,0,0,.1);padding:1.5rem;position:relative;transition:all .3s ease}.wp-block-ilb-icon-list .ilbIconList ul.theme7 .icon-sphere{height:70px;margin:0 auto 1.5rem;position:relative;width:70px}.wp-block-ilb-icon-list .ilbIconList ul.theme7 .theme7Icon{border-radius:50%;padding:12px}@keyframes rotateGradient{0%{transform:rotate(0deg)}to{transform:rotate(1turn)}}.wp-block-ilb-icon-list .ilbIconList ul.theme7 .icon-satellite{align-items:center;display:flex;height:100%;justify-content:center;position:relative;width:100%;z-index:2}.wp-block-ilb-icon-list .ilbIconList ul.theme7 .glass-card:hover .feature-icon{transform:scale(1.1)}.wp-block-ilb-icon-list .ilbIconList ul.theme7 .orbit{animation:orbitRotate 12s linear infinite;border-radius:50%;inset:-15px;position:absolute}@keyframes orbitRotate{0%{transform:rotate(0deg)}to{transform:rotate(1turn)}}.wp-block-ilb-icon-list .ilbIconList ul.theme7 .satellite{border-radius:50%;box-shadow:0 0 10px #fff;height:10px;position:absolute;width:10px}.wp-block-ilb-icon-list .ilbIconList ul.theme7 .satellite:first-child{left:50%;top:0}.wp-block-ilb-icon-list .ilbIconList ul.theme7 .satellite:nth-child(2){bottom:25%;right:0}.wp-block-ilb-icon-list .ilbIconList ul.theme7 .satellite:nth-child(3){bottom:25%;left:0}.wp-block-ilb-icon-list .ilbIconList ul.theme7 .text-content{position:relative;text-align:center;z-index:2}.wp-block-ilb-icon-list .ilbIconList ul.theme7 .hover-line{background:linear-gradient(90deg,rgba(147,51,234,.5),rgba(79,70,229,.5));bottom:0;height:2px;left:50%;position:absolute;transform:translateX(-50%);transition:width .4s ease;width:0}.wp-block-ilb-icon-list .ilbIconList ul.theme7 .glass-card:hover .hover-line{width:80%}
 
 </style>
-<link href="assets/56c98accff7adba92acbc1fe71f6bc218eeb9aa6643c45286a735a65000b35d9.css" id="fontAwesome-css" media="all" rel="stylesheet" type="text/css"/>
-<link href="assets/bcb99e11fbf6568a3e5b30cc14f67fe06f3f47c08eeea688d04ca8d3605ed542.css" id="mediaelement-css" media="all" rel="stylesheet" type="text/css"/>
-<link href="assets/1113013a6874efc4939b0f4f0c3f52f9bdec362b3f5e6019cf9459847468ebf7.css" id="wp-mediaelement-css" media="all" rel="stylesheet" type="text/css"/>
-<link href="assets/905f328b4040e094fed2533517af31557d4e457703e16bc937c375365a0c75b7.css" id="view_editor_gutenberg_frontend_assets-css" media="all" rel="stylesheet" type="text/css"/>
+<link href="../assets/56c98accff7adba92acbc1fe71f6bc218eeb9aa6643c45286a735a65000b35d9.css" id="fontAwesome-css" media="all" rel="stylesheet" type="text/css"/>
+<link href="../assets/bcb99e11fbf6568a3e5b30cc14f67fe06f3f47c08eeea688d04ca8d3605ed542.css" id="mediaelement-css" media="all" rel="stylesheet" type="text/css"/>
+<link href="../assets/1113013a6874efc4939b0f4f0c3f52f9bdec362b3f5e6019cf9459847468ebf7.css" id="wp-mediaelement-css" media="all" rel="stylesheet" type="text/css"/>
+<link href="../assets/905f328b4040e094fed2533517af31557d4e457703e16bc937c375365a0c75b7.css" id="view_editor_gutenberg_frontend_assets-css" media="all" rel="stylesheet" type="text/css"/>
 <style id="view_editor_gutenberg_frontend_assets-inline-css" type="text/css">
 .wpv-sort-list-dropdown.wpv-sort-list-dropdown-style-default > span.wpv-sort-list,.wpv-sort-list-dropdown.wpv-sort-list-dropdown-style-default .wpv-sort-list-item {border-color: #cdcdcd;}.wpv-sort-list-dropdown.wpv-sort-list-dropdown-style-default .wpv-sort-list-item a {color: #444;background-color: #fff;}.wpv-sort-list-dropdown.wpv-sort-list-dropdown-style-default a:hover,.wpv-sort-list-dropdown.wpv-sort-list-dropdown-style-default a:focus {color: #000;background-color: #eee;}.wpv-sort-list-dropdown.wpv-sort-list-dropdown-style-default .wpv-sort-list-item.wpv-sort-list-current a {color: #000;background-color: #eee;}
 .wpv-sort-list-dropdown.wpv-sort-list-dropdown-style-default > span.wpv-sort-list,.wpv-sort-list-dropdown.wpv-sort-list-dropdown-style-default .wpv-sort-list-item {border-color: #cdcdcd;}.wpv-sort-list-dropdown.wpv-sort-list-dropdown-style-default .wpv-sort-list-item a {color: #444;background-color: #fff;}.wpv-sort-list-dropdown.wpv-sort-list-dropdown-style-default a:hover,.wpv-sort-list-dropdown.wpv-sort-list-dropdown-style-default a:focus {color: #000;background-color: #eee;}.wpv-sort-list-dropdown.wpv-sort-list-dropdown-style-default .wpv-sort-list-item.wpv-sort-list-current a {color: #000;background-color: #eee;}.wpv-sort-list-dropdown.wpv-sort-list-dropdown-style-grey > span.wpv-sort-list,.wpv-sort-list-dropdown.wpv-sort-list-dropdown-style-grey .wpv-sort-list-item {border-color: #cdcdcd;}.wpv-sort-list-dropdown.wpv-sort-list-dropdown-style-grey .wpv-sort-list-item a {color: #444;background-color: #eeeeee;}.wpv-sort-list-dropdown.wpv-sort-list-dropdown-style-grey a:hover,.wpv-sort-list-dropdown.wpv-sort-list-dropdown-style-grey a:focus {color: #000;background-color: #e5e5e5;}.wpv-sort-list-dropdown.wpv-sort-list-dropdown-style-grey .wpv-sort-list-item.wpv-sort-list-current a {color: #000;background-color: #e5e5e5;}
@@ -288,24 +295,24 @@ window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/16
 :where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}
 :root :where(.wp-block-pullquote){font-size: 1.5em;line-height: 1.6;}
 </style>
-<link href="assets/da5c3933404d78e689e9a823d53cba52174b7029d31cc7861d99da2950863b64.css" id="cookie-notice-front-css" media="all" rel="stylesheet" type="text/css"/>
-<link href="assets/448e794ab832e84c0f808aa2c0b1c68a908107240f044d9938cddf2102a8b261.css" id="menu-image-css" media="all" rel="stylesheet" type="text/css"/>
-<link href="assets/096eac38f1daafc3abf9e2262dd08ec341d302f3f04400e055654048df39bacb.css" id="dashicons-css" media="all" rel="stylesheet" type="text/css"/>
-<link href="assets/afc2dff9e6f7a8658ee68a02e2fc086c69355a4a57453cbd006c07a26fb4c614.css" id="widgetopts-styles-css" media="all" rel="stylesheet" type="text/css"/>
-<link href="assets/397fab85136f43f52b43694c7c2e21c82a603c8bdf0fff02e1b96fe1c880c06f.css" id="wpml-legacy-horizontal-list-0-css" media="all" rel="stylesheet" type="text/css"/>
+<link href="../assets/da5c3933404d78e689e9a823d53cba52174b7029d31cc7861d99da2950863b64.css" id="cookie-notice-front-css" media="all" rel="stylesheet" type="text/css"/>
+<link href="../assets/448e794ab832e84c0f808aa2c0b1c68a908107240f044d9938cddf2102a8b261.css" id="menu-image-css" media="all" rel="stylesheet" type="text/css"/>
+<link href="../assets/096eac38f1daafc3abf9e2262dd08ec341d302f3f04400e055654048df39bacb.css" id="dashicons-css" media="all" rel="stylesheet" type="text/css"/>
+<link href="../assets/afc2dff9e6f7a8658ee68a02e2fc086c69355a4a57453cbd006c07a26fb4c614.css" id="widgetopts-styles-css" media="all" rel="stylesheet" type="text/css"/>
+<link href="../assets/397fab85136f43f52b43694c7c2e21c82a603c8bdf0fff02e1b96fe1c880c06f.css" id="wpml-legacy-horizontal-list-0-css" media="all" rel="stylesheet" type="text/css"/>
 <style id="wpml-legacy-horizontal-list-0-inline-css" type="text/css">
 .wpml-ls-statics-footer a, .wpml-ls-statics-footer .wpml-ls-sub-menu a, .wpml-ls-statics-footer .wpml-ls-sub-menu a:link, .wpml-ls-statics-footer li:not(.wpml-ls-current-language) .wpml-ls-link, .wpml-ls-statics-footer li:not(.wpml-ls-current-language) .wpml-ls-link:link {color:#444444;background-color:#ffffff;}.wpml-ls-statics-footer .wpml-ls-sub-menu a:hover,.wpml-ls-statics-footer .wpml-ls-sub-menu a:focus, .wpml-ls-statics-footer .wpml-ls-sub-menu a:link:hover, .wpml-ls-statics-footer .wpml-ls-sub-menu a:link:focus {color:#000000;background-color:#eeeeee;}.wpml-ls-statics-footer .wpml-ls-current-language > a {color:#444444;background-color:#ffffff;}.wpml-ls-statics-footer .wpml-ls-current-language:hover>a, .wpml-ls-statics-footer .wpml-ls-current-language>a:focus {color:#000000;background-color:#eeeeee;}
 </style>
-<link href="assets/05261b57040c045ef0cb8f307ab5733d6febe58c2dc6b1d7f4151df69118031d.css" id="wpml-menu-item-0-css" media="all" rel="stylesheet" type="text/css"/>
+<link href="../assets/05261b57040c045ef0cb8f307ab5733d6febe58c2dc6b1d7f4151df69118031d.css" id="wpml-menu-item-0-css" media="all" rel="stylesheet" type="text/css"/>
 <link href="https://fonts.googleapis.com/css?family=Domine%7CSource+Sans+Pro%3A400i%2C400%2C500%2C600%2C700&amp;ver=1.0.0" id="maitheme-google-fonts-css" media="all" rel="stylesheet" type="text/css"/>
-<link href="assets/03d602cabed80b9099361d9a0154bffed0e2892955bfcaea35994de29c51498d.css" id="mai-theme-engine-css" media="all" rel="stylesheet" type="text/css"/>
-<link href="assets/89a03ed69c529dd2dda783995003056678066bb707475e0a18295c37e11283d4.css" id="flexington-css" media="all" rel="stylesheet" type="text/css"/>
-<link href="assets/a5e33a4bfed606263eacd361419cc36b886dc85e2f337a01d1fa6ee6bef7767d.css" id="simple-social-icons-font-css" media="all" rel="stylesheet" type="text/css"/>
-<link href="assets/a6d304c4edeb0e78b815e5eb4f182fe4a0cc4f0a2f6598bc29f01a8ef8dfcbc5.css" id="slb_core-css" media="all" rel="stylesheet" type="text/css"/>
-<link href="assets/42860dcb53e95a60c59e8393cd96b4bd6d4a74fe3408be0791522619cab8ea6d.css" id="genesis-overrides-css-css" media="screen" rel="stylesheet" type="text/css"/>
-<link href="assets/87b4a29666485309b5ebd089caedc8d1d94ba524952c5b98d505987ae9cef0f1.css" id="mai-law-pro-css" media="all" rel="stylesheet" type="text/css"/>
-<script id="toolset-common-es-frontend-js" src="assets/7b0028f3d9366aae3a52cd7cb796e1c69506c038e535b812d8c00979658b0aa3.js" type="text/javascript"></script>
-<script async="async" data-wp-strategy="async" id="monsterinsights-frontend-script-js" src="assets/3770ce0ccde193ff99ec2d736b2bd914e44c0752a85048de4b5f8848a34938e5.js" type="text/javascript"></script>
+<link href="../assets/03d602cabed80b9099361d9a0154bffed0e2892955bfcaea35994de29c51498d.css" id="mai-theme-engine-css" media="all" rel="stylesheet" type="text/css"/>
+<link href="../assets/89a03ed69c529dd2dda783995003056678066bb707475e0a18295c37e11283d4.css" id="flexington-css" media="all" rel="stylesheet" type="text/css"/>
+<link href="../assets/a5e33a4bfed606263eacd361419cc36b886dc85e2f337a01d1fa6ee6bef7767d.css" id="simple-social-icons-font-css" media="all" rel="stylesheet" type="text/css"/>
+<link href="../assets/a6d304c4edeb0e78b815e5eb4f182fe4a0cc4f0a2f6598bc29f01a8ef8dfcbc5.css" id="slb_core-css" media="all" rel="stylesheet" type="text/css"/>
+<link href="../assets/42860dcb53e95a60c59e8393cd96b4bd6d4a74fe3408be0791522619cab8ea6d.css" id="genesis-overrides-css-css" media="screen" rel="stylesheet" type="text/css"/>
+<link href="../assets/87b4a29666485309b5ebd089caedc8d1d94ba524952c5b98d505987ae9cef0f1.css" id="mai-law-pro-css" media="all" rel="stylesheet" type="text/css"/>
+<script id="toolset-common-es-frontend-js" src="../assets/7b0028f3d9366aae3a52cd7cb796e1c69506c038e535b812d8c00979658b0aa3.js" type="text/javascript"></script>
+<script async="async" data-wp-strategy="async" id="monsterinsights-frontend-script-js" src="../assets/3770ce0ccde193ff99ec2d736b2bd914e44c0752a85048de4b5f8848a34938e5.js" type="text/javascript"></script>
 <script data-cfasync="false" data-wpfc-render="false" id="monsterinsights-frontend-script-js-extra" type="text/javascript">/* <![CDATA[ */
 var monsterinsights_frontend = {"js_events_tracking":"true","download_extensions":"doc,pdf,ppt,zip,xls,docx,pptx,xlsx","inbound_paths":"[{\"path\":\"\\\/go\\\/\",\"label\":\"affiliate\"},{\"path\":\"\\\/recommend\\\/\",\"label\":\"affiliate\"}]","home_url":"https:\/\/stabatmater.info","hash_tracking":"false","v4_id":"G-P3H9YYP0G1"};/* ]]> */
 </script>
@@ -314,26 +321,26 @@ var monsterinsights_frontend = {"js_events_tracking":"true","download_extensions
 var cnArgs = {"ajaxUrl":"https:\/\/stabatmater.info\/wp-admin\/admin-ajax.php","nonce":"0b05f5a7b1","hideEffect":"fade","position":"bottom","onScroll":false,"onScrollOffset":100,"onClick":false,"cookieName":"cookie_notice_accepted","cookieTime":2592000,"cookieTimeRejected":2592000,"globalCookie":false,"redirection":false,"cache":false,"revokeCookies":false,"revokeCookiesOpt":"automatic"};
 /* ]]> */
 </script>
-<script id="cookie-notice-front-js" src="assets/b7cd9a17a7636873e0d8394ba7dcd5ec596468da2ff03628f851bfd57d27108a.js" type="text/javascript"></script>
-<script id="jquery-core-js" src="assets/b7e4ca9159162614596eb36616f975c6563cbfb63d1424176a60f44803e2d709.js" type="text/javascript"></script>
-<script id="jquery-migrate-js" src="assets/9a955c3087f8a3702671cbe70146f5698945fc2d248640f3c03161a65f3bd662.js" type="text/javascript"></script>
+<script id="cookie-notice-front-js" src="../assets/b7cd9a17a7636873e0d8394ba7dcd5ec596468da2ff03628f851bfd57d27108a.js" type="text/javascript"></script>
+<script id="jquery-core-js" src="../assets/b7e4ca9159162614596eb36616f975c6563cbfb63d1424176a60f44803e2d709.js" type="text/javascript"></script>
+<script id="jquery-migrate-js" src="../assets/9a955c3087f8a3702671cbe70146f5698945fc2d248640f3c03161a65f3bd662.js" type="text/javascript"></script>
 <script id="defend-wp-firewall-nonce-js-extra" type="text/javascript">
 /* <![CDATA[ */
 var defend_wp_firewall_nonce_obj = {"defend_wp_firewall_nonce":"ea21f2c9e8","ajaxurl":"https:\/\/stabatmater.info\/wp-admin\/admin-ajax.php"};
 /* ]]> */
 </script>
-<script id="defend-wp-firewall-nonce-js" src="assets/3953c6b4ab3971dd4d18760361e4d27639aef8d37ac5376556e219826affd888.js" type="text/javascript"></script>
+<script id="defend-wp-firewall-nonce-js" src="../assets/3953c6b4ab3971dd4d18760361e4d27639aef8d37ac5376556e219826affd888.js" type="text/javascript"></script>
 <script id="defend-wp-firewall-blocklist-common-js-extra" type="text/javascript">
 /* <![CDATA[ */
 var defend_wp_firewall_common_blocklist_obj = {"security":"c7ed1570eb","ipify_ip":"","ajaxurl":"https:\/\/stabatmater.info\/wp-admin\/admin-ajax.php"};
 /* ]]> */
 </script>
-<script id="defend-wp-firewall-blocklist-common-js" src="assets/db63d6b35910c4040af4c432612b74a29d1f8c804f33b9af5a7779592ea0136c.js" type="text/javascript"></script>
-<link href="https://stabatmater.info/wp-json/" rel="https://api.w.org/"/><link href="https://stabatmater.info/wp-json/wp/v2/pages/2274" rel="alternate" title="JSON" type="application/json"/><link href="https://stabatmater.info/xmlrpc.php?rsd" rel="EditURI" title="RSD" type="application/rsd+xml"/>
+<script id="defend-wp-firewall-blocklist-common-js" src="../assets/db63d6b35910c4040af4c432612b74a29d1f8c804f33b9af5a7779592ea0136c.js" type="text/javascript"></script>
+<link href="https://stabatmater.info/wp-json/" rel="https://api.w.org/"/><link href="https://stabatmater.info/wp-json/wp/v2/posts/17686" rel="alternate" title="JSON" type="application/json"/><link href="https://stabatmater.info/xmlrpc.php?rsd" rel="EditURI" title="RSD" type="application/rsd+xml"/>
 <meta content="WordPress 6.8.2" name="generator"/>
-<link href="https://stabatmater.info/" rel="shortlink"/>
-<link href="https://stabatmater.info/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fstabatmater.info%2F" rel="alternate" title="oEmbed (JSON)" type="application/json+oembed"/>
-<link href="https://stabatmater.info/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fstabatmater.info%2F&amp;format=xml" rel="alternate" title="oEmbed (XML)" type="text/xml+oembed"/>
+<link href="https://stabatmater.info/?p=17686" rel="shortlink"/>
+<link href="https://stabatmater.info/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fstabatmater.info%2Fdonations-temporarily-unavailable%2F" rel="alternate" title="oEmbed (JSON)" type="application/json+oembed"/>
+<link href="https://stabatmater.info/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fstabatmater.info%2Fdonations-temporarily-unavailable%2F&amp;format=xml" rel="alternate" title="oEmbed (XML)" type="text/xml+oembed"/>
 <meta content="WPML ver:4.7.6 stt:37,1;" name="generator"/>
 <meta content="v1" name="tec-api-version"/><meta content="https://stabatmater.info" name="tec-api-origin"/><link href="https://stabatmater.info/wp-json/tribe/events/v1/" rel="alternate"/><script src="https://www.google.com/recaptcha/api.js"></script><style>
 	:root {
@@ -380,7 +387,7 @@ var defend_wp_firewall_common_blocklist_obj = {"security":"c7ed1570eb","ipify_ip
 	}
 	</style> <script> window.addEventListener("load",function(){ var c={script:false,link:false}; function ls(s) { if(!['script','link'].includes(s)||c[s]){return;}c[s]=true; var d=document,f=d.getElementsByTagName(s)[0],j=d.createElement(s); if(s==='script'){j.async=true;j.src='https://stabatmater.info/wp-content/plugins/wp-views/vendor/toolset/blocks/public/js/frontend.js?v=1.6.14';}else{ j.rel='stylesheet';j.href='https://stabatmater.info/wp-content/plugins/wp-views/vendor/toolset/blocks/public/css/style.css?v=1.6.14';} f.parentNode.insertBefore(j, f); }; function ex(){ls('script');ls('link')} window.addEventListener("scroll", ex, {once: true}); if (('IntersectionObserver' in window) && ('IntersectionObserverEntry' in window) && ('intersectionRatio' in window.IntersectionObserverEntry.prototype)) { var i = 0, fb = document.querySelectorAll("[class^='tb-']"), o = new IntersectionObserver(es => { es.forEach(e => { o.unobserve(e.target); if (e.intersectionRatio > 0) { ex();o.disconnect();}else{ i++;if(fb.length>i){o.observe(fb[i])}} }) }); if (fb.length) { o.observe(fb[i]) } } }) </script>
 <noscript>
-<link href="assets/e662f8135f4aabe7cadb9e1dc01d181eb71b3702374833f8be5d4dec679a8c22.css" rel="stylesheet"/>
+<link href="../assets/e662f8135f4aabe7cadb9e1dc01d181eb71b3702374833f8be5d4dec679a8c22.css" rel="stylesheet"/>
 </noscript><style type="text/css">.broken_link, a.broken_link {
 	text-decoration: line-through;
 }</style><style id="uagb-style-conditional-extension">@media (min-width: 1025px){body .uag-hide-desktop.uagb-google-map__wrap,body .uag-hide-desktop{display:none !important}}@media (min-width: 768px) and (max-width: 1024px){body .uag-hide-tab.uagb-google-map__wrap,body .uag-hide-tab{display:none !important}}@media (max-width: 767px){body .uag-hide-mob.uagb-google-map__wrap,body .uag-hide-mob{display:none !important}}</style><link href="https://stabatmater.info/wp-content/uploads/2020/11/cropped-cropped-stabat-mater-beeld-32x32.png" rel="icon" sizes="32x32">
@@ -659,7 +666,7 @@ ul.filter a:hover, ul.filter a.active {
 }
 .uagb-post__inner-wrap {
 
-	background-image:url('assets/24c87f9ec4779bc300e56fe1726846fc040af7a77f9743a65aabadb028529959.jpg')!important;
+	background-image:url('../assets/24c87f9ec4779bc300e56fe1726846fc040af7a77f9743a65aabadb028529959.jpg')!important;
 	background-repeat:no-repeat!important;
 	background-size:cover!important;
 }
@@ -792,7 +799,7 @@ time.uagb-post__date {
 }
 		</style>
 </meta></link></head>
-<body class="home wp-singular page-template-default page page-id-2274 wp-custom-logo wp-theme-genesis wp-child-theme-stabatmater-2 cookies-not-set tribe-no-js header-full-width content-sidebar genesis-breadcrumbs-hidden genesis-footer-widgets-visible has-standard-menu singular no-js has-banner-area text-md has-sidebar has-one-sidebar"> <script>
+<body class="wp-singular post-template-default single single-post postid-17686 single-format-standard wp-custom-logo wp-theme-genesis wp-child-theme-stabatmater-2 cookies-not-set tribe-no-js header-full-width content-sidebar genesis-breadcrumbs-hidden genesis-footer-widgets-visible has-standard-menu singular no-js has-banner-area text-md has-sidebar has-one-sidebar"> <script>
 		//<![CDATA[
 		( function() {
 			var c = document.body.classList;
@@ -801,60 +808,61 @@ time.uagb-post__date {
 		})();
 		//]]>
 	</script>
-<nav class="nav-third"><div class="wrap"><ul class="menu genesis-nav-menu menu-third responsive-menu" id="menu-topmenu"><li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7781" id="menu-item-7781"><a href="stabat-mater-collection-support/index.html">Donate</a></li>
+<nav class="nav-third"><div class="wrap"><ul class="menu genesis-nav-menu menu-third responsive-menu" id="menu-topmenu"><li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7781" id="menu-item-7781"><a href="../stabat-mater-collection-support/index.html">Donate</a></li>
 <li class="instagram menu-item menu-item-type-custom menu-item-object-custom menu-item-8389" id="menu-item-8389"><a href="https://www.instagram.com/stabatmater.info/"><span class="menu-image-title-hide menu-image-title">instagram</span><span class="dashicons dashicons-instagram hide-menu-image-icons"></span></a></li>
 <li class="youtube menu-item menu-item-type-custom menu-item-object-custom menu-item-8388" id="menu-item-8388"><a href="https://www.youtube.com/channel/UCPUZ1hgQgIIYQeMqoJWWoXw"><span class="menu-image-title-hide menu-image-title">Youtube</span><span class="dashicons dashicons-video-alt3 hide-menu-image-icons"></span></a></li>
 <li class="twitter menu-item menu-item-type-custom menu-item-object-custom menu-item-10243" id="menu-item-10243"><a href="https://twitter.com/StabatMaterSite"><span class="menu-image-title-hide menu-image-title">Twitter</span><span class="dashicons dashicons-twitter hide-menu-image-icons"></span></a></li>
-<li class="menu-item wpml-ls-slot-91 wpml-ls-item wpml-ls-item-nl wpml-ls-menu-item wpml-ls-first-item wpml-ls-last-item menu-item-type-wpml_ls_menu_item menu-item-object-wpml_ls_menu_item menu-item-wpml-ls-91-nl" id="menu-item-wpml-ls-91-nl"><a href="nl/index.html" title="Switch to "><img alt="Dutch" class="wpml-ls-flag" src="assets/bdb5ca399133d894a962b9d5d4b58618b82e6a63d5701fa5a6b40e8835a8b93f.png"/></a></li>
-</ul></div></nav><div class="site-container"><ul class="genesis-skip-link"><li><a class="screen-reader-shortcut" href="index.html"> Menu</a></li><li><a class="screen-reader-shortcut" href="index.html"> Skip to main content</a></li><li><a class="screen-reader-shortcut" href="index.html"> Skip to primary sidebar</a></li><li><a class="screen-reader-shortcut" href="index.html"> Skip to footer</a></li></ul><span id="header-trigger-wrap"><span id="header-trigger"></span></span><header class="site-header has-header-right"><div class="wrap"><div class="site-header-row row middle-xs between-xs"><div class="title-area col col-xs-auto start-xs"><p class="site-title"><a aria-current="page" class="custom-logo-link" href="index.html" rel="home"><img alt="The ultimate Stabat Mater site" class="custom-logo" decoding="async" fetchpriority="high" height="1200" sizes="(max-width: 984px) 100vw, 984px" src="assets/b78878a0cfcb67598353b8572618c0feca4584fd5de6c493bf738f9c0541dc10.png" srcset="assets/b78878a0cfcb67598353b8572618c0feca4584fd5de6c493bf738f9c0541dc10.png 984w, assets/b34fde7b1357ad12f76af5c18570923edd1990321cc31ccd218eb47744e337e8.png 246w, assets/ac8518cb73dd06f7921b03f52b046a64ced72c167a65dc6dc5a46cfa268b7e12.png 840w, assets/e471c05d4430918dab4043292b82c4322482656e727a54c00ef2d600dbf989e3.png 768w, assets/8b4af8e35d8ea268e4c594848ca805f5acf1c2aeb8baa279fd238d60ecaed0d9.png 20w, assets/4fc6365ca3fc1401801eb1ca4a12a7d485727da4949b6983bf0c81a0d2ac4c44.png 30w, assets/4bac1a9feb17b0771b3476fdd30dec318370b1c8db610bf12e1fbb275c1676d0.png 39w" width="984"/></a></p><p class="site-description screen-reader-text">a musical journey through the ages...</p></div><div class="header-right col col-xs text-xs-right"><aside class="widget-area"><h2 class="genesis-sidebar-title screen-reader-text">Header Right</h2><section class="widget widget_text" id="text-16"><div class="widget-wrap"> <div class="textwidget"><p class="site-titel">The Ultimate Stabat Mater Website </p>
+</ul></div></nav><div class="site-container"><ul class="genesis-skip-link"><li><a class="screen-reader-shortcut" href="index.html"> Menu</a></li><li><a class="screen-reader-shortcut" href="index.html"> Skip to main content</a></li><li><a class="screen-reader-shortcut" href="index.html"> Skip to primary sidebar</a></li><li><a class="screen-reader-shortcut" href="index.html"> Skip to footer</a></li></ul><span id="header-trigger-wrap"><span id="header-trigger"></span></span><header class="site-header has-header-right"><div class="wrap"><div class="site-header-row row middle-xs between-xs"><div class="title-area col col-xs-auto start-xs"><p class="site-title"><a class="custom-logo-link" href="../index.html" rel="home"><img alt="The ultimate Stabat Mater site" class="custom-logo" decoding="async" fetchpriority="high" height="1200" sizes="(max-width: 984px) 100vw, 984px" src="../assets/b78878a0cfcb67598353b8572618c0feca4584fd5de6c493bf738f9c0541dc10.png" srcset="../assets/b78878a0cfcb67598353b8572618c0feca4584fd5de6c493bf738f9c0541dc10.png 984w, ../assets/b34fde7b1357ad12f76af5c18570923edd1990321cc31ccd218eb47744e337e8.png 246w, ../assets/ac8518cb73dd06f7921b03f52b046a64ced72c167a65dc6dc5a46cfa268b7e12.png 840w, ../assets/e471c05d4430918dab4043292b82c4322482656e727a54c00ef2d600dbf989e3.png 768w, ../assets/8b4af8e35d8ea268e4c594848ca805f5acf1c2aeb8baa279fd238d60ecaed0d9.png 20w, ../assets/4fc6365ca3fc1401801eb1ca4a12a7d485727da4949b6983bf0c81a0d2ac4c44.png 30w, ../assets/4bac1a9feb17b0771b3476fdd30dec318370b1c8db610bf12e1fbb275c1676d0.png 39w" width="984"/></a></p><p class="site-description screen-reader-text">a musical journey through the ages...</p></div><div class="header-right col col-xs text-xs-right"><aside class="widget-area"><h2 class="genesis-sidebar-title screen-reader-text">Header Right</h2><section class="widget widget_text" id="text-16"><div class="widget-wrap"> <div class="textwidget"><p class="site-titel">The Ultimate Stabat Mater Website </p>
 <p class="site-omschrijving">a musical journey through the ages</p>
 </div>
 </div></section>
-</aside></div></div><div class="mai-menu" id="mai-menu"><div class="mai-menu-outer"><div class="mai-menu-inner"><form action="https://stabatmater.info/" class="search-form" method="get" role="search"><label class="search-form-label screen-reader-text" for="searchform-2">Search this website</label><input class="search-form-input" id="searchform-2" name="s" placeholder="Search this website" type="search"/><input class="search-form-submit" type="submit" value="Search"/><meta content="https://stabatmater.info/?s={s}"/></form><div class="menu-hoofdmenu-container"><ul class="menu" id="menu-hoofdmenu"><li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-home current-menu-item page_item page-item-2274 current_page_item menu-item-9483" id="menu-item-9483"><a aria-current="page" href="index.html">Home</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-9536" id="menu-item-9536"><a href="stabat-mater-composer/index.html">Composers</a>
+</aside></div></div><div class="mai-menu" id="mai-menu"><div class="mai-menu-outer"><div class="mai-menu-inner"><form action="https://stabatmater.info/" class="search-form" method="get" role="search"><label class="search-form-label screen-reader-text" for="searchform-2">Search this website</label><input class="search-form-input" id="searchform-2" name="s" placeholder="Search this website" type="search"/><input class="search-form-submit" type="submit" value="Search"/><meta content="https://stabatmater.info/?s={s}"/></form><div class="menu-hoofdmenu-container"><ul class="menu" id="menu-hoofdmenu"><li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-home menu-item-9483" id="menu-item-9483"><a href="../index.html">Home</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-9536" id="menu-item-9536"><a href="../stabat-mater-composer/index.html">Composers</a>
 <ul class="sub-menu">
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9562" id="menu-item-9562"><a href="stabat-mater-composer/alphabetically/index.html">Alphabetically</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9561" id="menu-item-9561"><a href="stabat-mater-composer/countries-of-origin/index.html">By country of origin</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9563" id="menu-item-9563"><a href="stabat-mater-composer/chronologically/index.html">Chronologically</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9567" id="menu-item-9567"><a href="stabat-mater-composer/duration/index.html">By duration</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9562" id="menu-item-9562"><a href="../stabat-mater-composer/alphabetically/index.html">Alphabetically</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9561" id="menu-item-9561"><a href="../stabat-mater-composer/countries-of-origin/index.html">By country of origin</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9563" id="menu-item-9563"><a href="../stabat-mater-composer/chronologically/index.html">Chronologically</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9567" id="menu-item-9567"><a href="../stabat-mater-composer/duration/index.html">By duration</a></li>
 </ul>
 </li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9485" id="menu-item-9485"><a href="stabat-mater-dolorosa-about-the-poem/index.html">Texts</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9538" id="menu-item-9538"><a href="stabat-mater-translations-and-languages/index.html">Translations</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9489" id="menu-item-9489"><a href="stabat-mater-blog/index.html">Blog</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9560" id="menu-item-9560"><a href="stabat-mater-cd-collection/index.html">Missing CDs</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9486" id="menu-item-9486"><a href="stabat-mater-foundation/index.html">About</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5469" id="menu-item-5469"><a href="stabat-mater-collection-support/index.html">Donate?</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9492" id="menu-item-9492"><a href="contact/index.html">Contact</a></li>
-</ul></div></div></div></div></div></header><section class="section banner-area width-full has-bg-image light-content" style="background-color: #f1f1f1;"><picture class="bg-picture"><source media="(max-width: 260px)" srcset="assets/7803b5d3cb64f8ebc3d9bd3ba9e635d7936b3e99a80b6c77c55c1ce1eb45863a.jpg"/><source media="(max-width: 350px)" srcset="assets/969f4fcacb0c60662dac29938d1bb8801ea72be4cbbcf91d3d2da302a86db69b.jpg"/><source media="(max-width: 550px)" srcset="assets/263b87c2fc0630dc12913eb82567ec7198921220053f9f847816bc63601b565b.jpg"/><source media="(max-width: 800px)" srcset="assets/161ec7906e9f9c12189460dfa5ff8748f6767bef1a35c40cfe800a63563f87f4.jpg"/><img alt="" class="bg-image" decoding="async" height="340" sizes="(max-width: 1200px) 100vw, 1200px" src="assets/6d3da5459f11e72979942abce53ccfe1bb939d8f5d358fc3a00da8f533169cde.jpg" srcset="assets/6d3da5459f11e72979942abce53ccfe1bb939d8f5d358fc3a00da8f533169cde.jpg 1200w, assets/ad432f6d2274057bd803a9ff686731805a7a49d9b8b1b6593a02ca770fd8b169.jpg 300w, assets/dce59910e5c518b4240e40e88e2341ced4a21655cb12a1f8a9cbdbd0dabace1b.jpg 1024w, assets/7404051dcac755a9301c068bf7ee8fc9474a3f0222c16f52a461dc79fe1e97f2.jpg 768w" width="1200"/></picture><div class="wrap height-lg center-xs text-xs-center text-lg"><div class="section-content width-auto"><h1 class="banner-title">Explore the Timeless Legacy of the Stabat Mater</h1>
-</div></div></section><nav class="nav-secondary"><div class="wrap"><ul class="menu genesis-nav-menu menu-secondary responsive-menu" id="menu-hoofdmenu-1"><li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-home current-menu-item page_item page-item-2274 current_page_item menu-item-9483"><a aria-current="page" href="index.html">Home</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-9536"><a href="stabat-mater-composer/index.html">Composers</a>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9485" id="menu-item-9485"><a href="../stabat-mater-dolorosa-about-the-poem/index.html">Texts</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9538" id="menu-item-9538"><a href="../stabat-mater-translations-and-languages/index.html">Translations</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9489" id="menu-item-9489"><a href="../stabat-mater-blog/index.html">Blog</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9560" id="menu-item-9560"><a href="../stabat-mater-cd-collection/index.html">Missing CDs</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9486" id="menu-item-9486"><a href="../stabat-mater-foundation/index.html">About</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5469" id="menu-item-5469"><a href="../stabat-mater-collection-support/index.html">Donate?</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9492" id="menu-item-9492"><a href="../contact/index.html">Contact</a></li>
+</ul></div></div></div></div></div></header><section class="section banner-area width-full has-bg-image light-content" style="background-color: #f1f1f1;"><picture class="bg-picture"><source media="(max-width: 260px)" srcset="../assets/e91c0c972866300f32118906ebbdd5726dffbfd9e4c2165de5082fcffd121843.jpg"/><source media="(max-width: 350px)" srcset="../assets/fa6849c1b9aa94187af052e9f3e3bd00ec2c5ef173964f32f2ddaa446cf4dde6.jpg"/><source media="(max-width: 550px)" srcset="../assets/fb708ed0416aead5854a4a6644de9a14123d97acba4dc20066e31d166305ab4c.jpg"/><source media="(max-width: 800px)" srcset="../assets/3133f75941a859ca757e8ceca500a202bd7018d036e2ca4c328dd5d08d3745ed.jpg"/><img alt="" class="bg-image" decoding="async" height="340" sizes="(max-width: 1200px) 100vw, 1200px" src="../assets/19711dd80a6c2a3c23bf1e4306d3d328aa36a41661e3470efb2019e6f8ace7ae.jpg" srcset="../assets/19711dd80a6c2a3c23bf1e4306d3d328aa36a41661e3470efb2019e6f8ace7ae.jpg 1200w, ../assets/b1439b6f8f8ed271e2ef703be23f2037751e25ae0881bfb940e2dfd2087ddb65.jpg 300w, ../assets/e04cf906c335d0b807ffe2f79232922720c73f5269b66fe8754082760f291f06.jpg 1024w, ../assets/675ea241fe23065e77eb3894a757818fbac0618c3f17ab2bb47859267ae863b4.jpg 768w" width="1200"/></picture><div class="wrap height-lg center-xs text-xs-center text-lg"><div class="section-content width-auto"><h1 class="banner-title">Donations temporarily unavailable</h1>
+</div></div></section><nav class="nav-secondary"><div class="wrap"><ul class="menu genesis-nav-menu menu-secondary responsive-menu" id="menu-hoofdmenu-1"><li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-home menu-item-9483"><a href="../index.html">Home</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-9536"><a href="../stabat-mater-composer/index.html">Composers</a>
 <ul class="sub-menu">
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9562"><a href="stabat-mater-composer/alphabetically/index.html">Alphabetically</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9561"><a href="stabat-mater-composer/countries-of-origin/index.html">By country of origin</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9563"><a href="stabat-mater-composer/chronologically/index.html">Chronologically</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9567"><a href="stabat-mater-composer/duration/index.html">By duration</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9562"><a href="../stabat-mater-composer/alphabetically/index.html">Alphabetically</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9561"><a href="../stabat-mater-composer/countries-of-origin/index.html">By country of origin</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9563"><a href="../stabat-mater-composer/chronologically/index.html">Chronologically</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9567"><a href="../stabat-mater-composer/duration/index.html">By duration</a></li>
 </ul>
 </li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9485"><a href="stabat-mater-dolorosa-about-the-poem/index.html">Texts</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9538"><a href="stabat-mater-translations-and-languages/index.html">Translations</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9489"><a href="stabat-mater-blog/index.html">Blog</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9560"><a href="stabat-mater-cd-collection/index.html">Missing CDs</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9486"><a href="stabat-mater-foundation/index.html">About</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5469"><a href="stabat-mater-collection-support/index.html">Donate?</a></li>
-<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9492"><a href="contact/index.html">Contact</a></li>
-</ul></div></nav><div class="site-inner"><header class="entry-header"><h1 class="entry-title">Explore the Timeless Legacy of the Stabat Mater</h1>
-</header><div class="content-sidebar-wrap has-boxed-children"><main class="content" id="genesis-content"><article aria-label="Explore the Timeless Legacy of the Stabat Mater" class="post-2274 page type-page status-publish entry boxed"><div class="entry-content">
-<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
-<iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="" frameborder="0" height="281" referrerpolicy="strict-origin-when-cross-origin" src="https://www.youtube.com/embed/BB51Wb2UvbI?feature=oembed" title="Stabat Mater Dolorosa - A Journey through Seven Centuries of Music" width="500"></iframe>
-</div><figcaption class="wp-element-caption"><strong>If you wou</strong>ld like to support us in keeping the website ad-free, you might consider making a <a href="stabat-mater-collection-support/index.html">donation</a> or purchasing the <a href="https://www.amazon.com/Stabat-Mater-Dolorosa-Journey-Centuries/dp/B0CY8T9MG1">Stabat Mater Dolorosa book</a>. Thank you so much!</figcaption></figure>
-<h2 class="wp-block-heading">Search the Ultimate Stabat Mater Website</h2>
-<p>On the Ultimate Stabat Mater Website you will find the CD-collection of -now- more than 300 different Stabat Mater compositions. Search for <a href="stabat-mater-composer/index.html">composers</a>: alphabetically, chronologically, by country of origin and by duration. <a href="https://www.youtube.com/channel/UCPUZ1hgQgIIYQeMqoJWWoXw">Listen</a> to the compositions and <a href="https://www.youtube.com/channel/UCPUZ1hgQgIIYQeMqoJWWoXw/featured">watch</a> the videos of special performances. The site also includes <a href="stabat-mater-translations-and-languages/index.html">translations</a> of the original Latin poem <a href="stabat-mater-dolorosa-about-the-poem/index.html">Stabat Mater Dolorosa</a> in 24 different languages. See: <a href="category/latest-addition/index.html">Latest additions</a>.</p>
-<h2 class="wp-block-heading">Why this Stabat Mater website?&nbsp;&nbsp;</h2>
-<p>Initiator of this website, <a href="stabat-mater-foundation/index.html">Hans van der Velden</a>, began this journey of musical discovery in 1992 with the Stabat Mater from <a href="stabat-mater-foundation/index.html">Haydn</a>. He searched systematically and persistently for composers, performances on cd and translations of the original Latin poem. He brought the religious, literary, and musical world of the Stabat Mater to life. <a href="stabat-mater-foundation/index.html">We are proud</a> to continue his work.</p>
-<h2 class="wp-block-heading">Interested?</h2>
-<p>We hope this site is helpful for music lovers, musicians, and composers! Would you like to learn more? Subscribe to the Newsletter or <a href="stabat-mater-blog/index.html">read the blog</a>. Do you have any information about performances, recordings, video&rsquo;s, or cds with Stabat Maters? &nbsp;<a href="contact/index.html">Please, let us know</a>!</p>
-</div></article></main><aside aria-label="Primary Sidebar" class="sidebar sidebar-primary widget-area has-boxed" id="genesis-sidebar-primary" role="complementary"><h2 class="genesis-sidebar-title screen-reader-text">Primary Sidebar</h2><section class="widget boxed widget_text" id="text-60"><div class="widget-wrap"> <div class="textwidget"><p><a href="stabat-mater-collection-support/index.html"><img alt="" class="alignnone size-medium wp-image-17330" decoding="async" height="175" loading="lazy" sizes="auto, (max-width: 300px) 100vw, 300px" src="assets/16fecb4e78f850ce9a99d1bd043574dc068e69ff555a4aeed231e142ada51cc1.jpg" srcset="assets/16fecb4e78f850ce9a99d1bd043574dc068e69ff555a4aeed231e142ada51cc1.jpg 300w, assets/66a3858ef0021a6029b0ddd689676ca1ac9543165a40482e328b653f7661998e.jpg 24w, assets/2aca9f062eedcd1e5184b132a72b87aa10f2ae0f6e1961a60a44b43b5cde74b7.jpg 36w, assets/d120e9a2c3a0d229938d15e0d8f706f817b1c2765c012c086897350b4b351f8f.jpg 48w" width="300"/></a></p>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9485"><a href="../stabat-mater-dolorosa-about-the-poem/index.html">Texts</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9538"><a href="../stabat-mater-translations-and-languages/index.html">Translations</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9489"><a href="../stabat-mater-blog/index.html">Blog</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9560"><a href="../stabat-mater-cd-collection/index.html">Missing CDs</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9486"><a href="../stabat-mater-foundation/index.html">About</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5469"><a href="../stabat-mater-collection-support/index.html">Donate?</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9492"><a href="../contact/index.html">Contact</a></li>
+</ul></div></nav><div class="site-inner"><header class="entry-header"><h1 class="entry-title">Donations temporarily unavailable</h1>
+</header><div class="content-sidebar-wrap has-boxed-children"><main class="content" id="genesis-content"><article aria-label="Donations temporarily unavailable" class="post-20050 post type-post status-publish format-standard category-stabat-mater entry boxed"><header class="entry-header"><p class="entry-meta"><time class="entry-time">20-04-2025</time></p></header><div class="entry-content">
+<p>Thank you for supporting the Ultimate Stabat Mater Website. While we prepare a new and more secure donation flow, we need to pause online contributions for a short time.</p>
+<div class="wp-block-image">
+<figure class="aligncenter size-medium"><img alt="" class="wp-image-17330" decoding="async" height="175" loading="lazy" sizes="(max-width: 300px) 100vw, 300px" src="../assets/16fecb4e78f850ce9a99d1bd043574dc068e69ff555a4aeed231e142ada51cc1.jpg" srcset="../assets/16fecb4e78f850ce9a99d1bd043574dc068e69ff555a4aeed231e142ada51cc1.jpg 300w, ../assets/66a3858ef0021a6029b0ddd689676ca1ac9543165a40482e328b653f7661998e.jpg 24w, ../assets/2aca9f062eedcd1e5184b132a72b87aa10f2ae0f6e1961a60a44b43b5cde74b7.jpg 36w, ../assets/d120e9a2c3a0d229938d15e0d8f706f817b1c2765c012c086897350b4b351f8f.jpg 48w" width="300"/></figure>
+</div>
+<p>We expect to reopen online giving shortly and will post an update as soon as the form returns. Until then, every gesture of encouragement helps:</p>
+<ul>
+<li>Send us a note through the <a href="../contact/index.html">contact page</a> if you would like bank-transfer details.</li>
+<li>Support the archive by ordering the <a href="https://www.amazon.com/Stabat-Mater-Dolorosa-Journey-Centuries/dp/B0CY8T9MG1">Stabat Mater Dolorosa book</a>.</li>
+<li>Share the website or our newsletter with friends who love sacred music.</li>
+</ul>
+<p>Your generosity keeps this ad-free resource alive. Thank you for your patience while we finish the upgrade and for standing with the Stabat Mater community.</p>
+</div></div><footer class="entry-footer"><p class="entry-meta"><span class="entry-terms">Category: <a href="../category/stabat-mater/index.html" rel="tag">Stabat Mater</a></span></p></footer></article><div class="adjacent-entry-pagination pagination boxed"><div class="pagination-previous"><a class="boxed" href="../a-unique-approach-to-pergolesis-stabat-mater/index.html" rel="prev"><span class="screen-reader-text">Previous Post: </span><span class="adjacent-post-link"><span class="pagination-icon">&laquo;</span> A Unique Approach to Pergolesi&rsquo;s Stabat Mater</span></a></div><div class="pagination-next"></div></div></main><aside aria-label="Primary Sidebar" class="sidebar sidebar-primary widget-area has-boxed" id="genesis-sidebar-primary" role="complementary"><h2 class="genesis-sidebar-title screen-reader-text">Primary Sidebar</h2><section class="widget boxed widget_text" id="text-60"><div class="widget-wrap"> <div class="textwidget"><p><a href="../stabat-mater-collection-support/index.html"><img alt="" class="alignnone size-medium wp-image-17330" decoding="async" height="175" loading="lazy" sizes="auto, (max-width: 300px) 100vw, 300px" src="../assets/16fecb4e78f850ce9a99d1bd043574dc068e69ff555a4aeed231e142ada51cc1.jpg" srcset="../assets/16fecb4e78f850ce9a99d1bd043574dc068e69ff555a4aeed231e142ada51cc1.jpg 300w, ../assets/66a3858ef0021a6029b0ddd689676ca1ac9543165a40482e328b653f7661998e.jpg 24w, ../assets/2aca9f062eedcd1e5184b132a72b87aa10f2ae0f6e1961a60a44b43b5cde74b7.jpg 36w, ../assets/d120e9a2c3a0d229938d15e0d8f706f817b1c2765c012c086897350b4b351f8f.jpg 48w" width="300"/></a></p>
 </div>
 </div></section>
 <section class="widget boxed widget_search" id="search-5"><div class="widget-wrap"><form action="https://stabatmater.info/" class="search-form" method="get" role="search"><label class="search-form-label screen-reader-text" for="searchform-3">Search this website</label><input class="search-form-input" id="searchform-3" name="s" placeholder="Search this website" type="search"/><input class="search-form-submit" type="submit" value="Search"/><meta content="https://stabatmater.info/?s={s}"/></form></div></section>
@@ -862,47 +870,181 @@ time.uagb-post__date {
 <h3 class="widgettitle widget-title">Recent posts</h3>
 <ul>
 <li>
-<a href="donations-temporarily-unavailable/index.html">Donations temporarily unavailable</a>
+<a aria-current="page" href="index.html">Donations temporarily unavailable</a>
 <span class="post-date">20-04-2025</span>
 </li>
 <li>
-<a href="a-unique-approach-to-pergolesis-stabat-mater/index.html">A Unique Approach to Pergolesi&rsquo;s Stabat Mater</a>
+<a href="../a-unique-approach-to-pergolesis-stabat-mater/index.html">A Unique Approach to Pergolesi&rsquo;s Stabat Mater</a>
 <span class="post-date">13-04-2025</span>
 </li>
 <li>
-<a href="latest-addition-clemence-de-granval/index.html">Latest addition: Cl&eacute;mence de Granval</a>
+<a href="../latest-addition-clemence-de-granval/index.html">Latest addition: Cl&eacute;mence de Granval</a>
 <span class="post-date">18-03-2025</span>
 </li>
 <li>
-<a href="new-english-liturgical-translation-of-the-stabat-mater/index.html">New English Liturgical Translation of the Stabat Mater</a>
+<a href="../new-english-liturgical-translation-of-the-stabat-mater/index.html">New English Liturgical Translation of the Stabat Mater</a>
 <span class="post-date">18-03-2025</span>
 </li>
 <li>
-<a href="the-ultimate-stabat-mater-website-needs-your-support/index.html">The Ultimate Stabat Mater Website Needs Your Support</a>
+<a href="../the-ultimate-stabat-mater-website-needs-your-support/index.html">The Ultimate Stabat Mater Website Needs Your Support</a>
 <span class="post-date">06-02-2025</span>
 </li>
 </ul>
 </div></section>
 <section class="widget boxed widget_text" id="text-28"><div class="widget-wrap"><h3 class="widgettitle widget-title">Stabat Mater composers</h3>
 <div class="textwidget"><p>Search for composers:<br/>
-<a href="stabat-mater-composer/alphabetically/index.html">Alphabetically</a><br/>
-<a href="stabat-mater-composer/countries-of-origin/index.html">By countries of origin</a><br/>
-<a href="stabat-mater-composer/chronologically/index.html">Chronologically</a><br/>
-<a href="stabat-mater-composer/duration/index.html">By duration</a></p>
+<a href="../stabat-mater-composer/alphabetically/index.html">Alphabetically</a><br/>
+<a href="../stabat-mater-composer/countries-of-origin/index.html">By countries of origin</a><br/>
+<a href="../stabat-mater-composer/chronologically/index.html">Chronologically</a><br/>
+<a href="../stabat-mater-composer/duration/index.html">By duration</a></p>
 </div>
 </div></section>
+<section class="widget boxed widget_categories" id="categories-2"><div class="widget-wrap"><h3 class="widgettitle widget-title">Categories</h3>
+<form action="https://stabatmater.info" method="get"><label class="screen-reader-text" for="cat">Categories</label><select class="postform" id="cat" name="cat">
+<option value="-1">Select Category</option>
+<option class="level-0" value="86">Art</option>
+<option class="level-0" value="152">composer</option>
+<option class="level-0" value="70">Concerts</option>
+<option class="level-0" value="115">Jacopone</option>
+<option class="level-0" value="77">Latest addition</option>
+<option class="level-0" value="123">Literature</option>
+<option class="level-0" value="119">Missing CD</option>
+<option class="level-0" value="76">New Stabat Mater</option>
+<option class="level-0" value="6">News</option>
+<option class="level-0" value="138">poetry</option>
+<option class="level-0" value="72">Stabat Mater</option>
+<option class="level-0" value="79">Translation</option>
+<option class="level-0" value="132">Video Art</option>
+<option class="level-0" value="122">Virtual performance</option>
+<option class="level-0" value="137">woman composer</option>
+</select>
+</form><script type="text/javascript">
+/* <![CDATA[ */
+
+(function() {
+	var dropdown = document.getElementById( "cat" );
+	function onCatChange() {
+		if ( dropdown.options[ dropdown.selectedIndex ].value > 0 ) {
+			dropdown.parentNode.submit();
+		}
+	}
+	dropdown.onchange = onCatChange;
+})();
+
+/* ]]> */
+</script>
+</div></section>
+<section class="widget boxed widget_archive" id="archives-2"><div class="widget-wrap"><h3 class="widgettitle widget-title">Archives</h3>
+<label class="screen-reader-text" for="archives-dropdown-2">Archives</label>
+<select id="archives-dropdown-2" name="archive-dropdown">
+<option value="">Select Month</option>
+<option value="https://stabatmater.info/2025/04/"> April 2025 </option>
+<option value="https://stabatmater.info/2025/03/"> March 2025 </option>
+<option value="https://stabatmater.info/2025/02/"> February 2025 </option>
+<option value="https://stabatmater.info/2024/12/"> December 2024 </option>
+<option value="https://stabatmater.info/2024/11/"> November 2024 </option>
+<option value="https://stabatmater.info/2024/09/"> September 2024 </option>
+<option value="https://stabatmater.info/2024/07/"> July 2024 </option>
+<option value="https://stabatmater.info/2024/06/"> June 2024 </option>
+<option value="https://stabatmater.info/2024/05/"> May 2024 </option>
+<option value="https://stabatmater.info/2024/04/"> April 2024 </option>
+<option value="https://stabatmater.info/2024/03/"> March 2024 </option>
+<option value="https://stabatmater.info/2024/01/"> January 2024 </option>
+<option value="https://stabatmater.info/2023/11/"> November 2023 </option>
+<option value="https://stabatmater.info/2023/10/"> October 2023 </option>
+<option value="https://stabatmater.info/2023/09/"> September 2023 </option>
+<option value="https://stabatmater.info/2023/08/"> August 2023 </option>
+<option value="https://stabatmater.info/2023/06/"> June 2023 </option>
+<option value="https://stabatmater.info/2023/05/"> May 2023 </option>
+<option value="https://stabatmater.info/2023/04/"> April 2023 </option>
+<option value="https://stabatmater.info/2023/02/"> February 2023 </option>
+<option value="https://stabatmater.info/2023/01/"> January 2023 </option>
+<option value="https://stabatmater.info/2022/11/"> November 2022 </option>
+<option value="https://stabatmater.info/2022/09/"> September 2022 </option>
+<option value="https://stabatmater.info/2022/06/"> June 2022 </option>
+<option value="https://stabatmater.info/2022/04/"> April 2022 </option>
+<option value="https://stabatmater.info/2022/03/"> March 2022 </option>
+<option value="https://stabatmater.info/2022/02/"> February 2022 </option>
+<option value="https://stabatmater.info/2022/01/"> January 2022 </option>
+<option value="https://stabatmater.info/2021/12/"> December 2021 </option>
+<option value="https://stabatmater.info/2021/11/"> November 2021 </option>
+<option value="https://stabatmater.info/2021/10/"> October 2021 </option>
+<option value="https://stabatmater.info/2021/08/"> August 2021 </option>
+<option value="https://stabatmater.info/2021/07/"> July 2021 </option>
+<option value="https://stabatmater.info/2021/05/"> May 2021 </option>
+<option value="https://stabatmater.info/2021/03/"> March 2021 </option>
+<option value="https://stabatmater.info/2020/11/"> November 2020 </option>
+<option value="https://stabatmater.info/2020/10/"> October 2020 </option>
+<option value="https://stabatmater.info/2020/09/"> September 2020 </option>
+<option value="https://stabatmater.info/2020/08/"> August 2020 </option>
+<option value="https://stabatmater.info/2020/06/"> June 2020 </option>
+<option value="https://stabatmater.info/2020/05/"> May 2020 </option>
+<option value="https://stabatmater.info/2020/04/"> April 2020 </option>
+<option value="https://stabatmater.info/2020/02/"> February 2020 </option>
+<option value="https://stabatmater.info/2020/01/"> January 2020 </option>
+<option value="https://stabatmater.info/2019/12/"> December 2019 </option>
+<option value="https://stabatmater.info/2019/11/"> November 2019 </option>
+<option value="https://stabatmater.info/2019/10/"> October 2019 </option>
+<option value="https://stabatmater.info/2019/07/"> July 2019 </option>
+<option value="https://stabatmater.info/2019/05/"> May 2019 </option>
+<option value="https://stabatmater.info/2019/04/"> April 2019 </option>
+<option value="https://stabatmater.info/2019/03/"> March 2019 </option>
+<option value="https://stabatmater.info/2019/02/"> February 2019 </option>
+<option value="https://stabatmater.info/2019/01/"> January 2019 </option>
+<option value="https://stabatmater.info/2018/10/"> October 2018 </option>
+<option value="https://stabatmater.info/2018/09/"> September 2018 </option>
+<option value="https://stabatmater.info/2018/08/"> August 2018 </option>
+<option value="https://stabatmater.info/2018/06/"> June 2018 </option>
+<option value="https://stabatmater.info/2018/04/"> April 2018 </option>
+<option value="https://stabatmater.info/2018/03/"> March 2018 </option>
+<option value="https://stabatmater.info/2017/12/"> December 2017 </option>
+<option value="https://stabatmater.info/2017/11/"> November 2017 </option>
+<option value="https://stabatmater.info/2017/10/"> October 2017 </option>
+<option value="https://stabatmater.info/2017/08/"> August 2017 </option>
+<option value="https://stabatmater.info/2017/03/"> March 2017 </option>
+<option value="https://stabatmater.info/2017/02/"> February 2017 </option>
+<option value="https://stabatmater.info/2017/01/"> January 2017 </option>
+<option value="https://stabatmater.info/2016/11/"> November 2016 </option>
+<option value="https://stabatmater.info/2016/10/"> October 2016 </option>
+<option value="https://stabatmater.info/2016/09/"> September 2016 </option>
+<option value="https://stabatmater.info/2016/08/"> August 2016 </option>
+<option value="https://stabatmater.info/2016/06/"> June 2016 </option>
+<option value="https://stabatmater.info/2016/05/"> May 2016 </option>
+<option value="https://stabatmater.info/2016/04/"> April 2016 </option>
+<option value="https://stabatmater.info/2016/03/"> March 2016 </option>
+<option value="https://stabatmater.info/2016/02/"> February 2016 </option>
+<option value="https://stabatmater.info/2016/01/"> January 2016 </option>
+<option value="https://stabatmater.info/2015/12/"> December 2015 </option>
+<option value="https://stabatmater.info/2015/11/"> November 2015 </option>
+</select>
+<script type="text/javascript">
+/* <![CDATA[ */
+
+(function() {
+	var dropdown = document.getElementById( "archives-dropdown-2" );
+	function onSelectChange() {
+		if ( dropdown.options[ dropdown.selectedIndex ].value !== '' ) {
+			document.location.href = this.options[ this.selectedIndex ].value;
+		}
+	}
+	dropdown.onchange = onSelectChange;
+})();
+
+/* ]]> */
+</script>
+</div></section>
 </aside></div></div><div class="footer-widgets" id="genesis-footer-widgets"><h2 class="genesis-sidebar-title screen-reader-text">Footer</h2><div class="wrap"><div class="row gutter-xl"><div class="widget-area footer-widgets-1 footer-widget-area col col-xs-12 col-sm-6 col-md-3"><section class="widget widget_text" id="text-43"><div class="widget-wrap"><h3 class="widgettitle widget-title">Visit YouTube</h3>
-<div class="textwidget"><p><a href="https://www.youtube.com/channel/UCPUZ1hgQgIIYQeMqoJWWoXw" rel="noopener" target="_blank"><img alt="" class="alignnone size-full wp-image-11737" decoding="async" height="178" loading="lazy" sizes="auto, (max-width: 297px) 100vw, 297px" src="assets/de1bb35313215d0c4f14c283d836d29e63b3840977a67decc4bb9f4a75ee0814.jpg" srcset="assets/de1bb35313215d0c4f14c283d836d29e63b3840977a67decc4bb9f4a75ee0814.jpg 297w, assets/4d7776a76a7fdfedbba10dbbc0cfc8d93d30d50d0a423bea0f3ecb95a782bdd7.jpg 24w, assets/6ba7df2aa3dc789760f56bb2e5c799bec651f587dfcff1573e5521cc9fa1ae84.jpg 36w, assets/af3e8a14bab08606a8294cc030c2bfe166ee169c41729664557e463cbf83507b.jpg 48w" width="297"/></a><br/>
+<div class="textwidget"><p><a href="https://www.youtube.com/channel/UCPUZ1hgQgIIYQeMqoJWWoXw" rel="noopener" target="_blank"><img alt="" class="alignnone size-full wp-image-11737" decoding="async" height="178" loading="lazy" sizes="auto, (max-width: 297px) 100vw, 297px" src="../assets/de1bb35313215d0c4f14c283d836d29e63b3840977a67decc4bb9f4a75ee0814.jpg" srcset="../assets/de1bb35313215d0c4f14c283d836d29e63b3840977a67decc4bb9f4a75ee0814.jpg 297w, ../assets/4d7776a76a7fdfedbba10dbbc0cfc8d93d30d50d0a423bea0f3ecb95a782bdd7.jpg 24w, ../assets/6ba7df2aa3dc789760f56bb2e5c799bec651f587dfcff1573e5521cc9fa1ae84.jpg 36w, ../assets/af3e8a14bab08606a8294cc030c2bfe166ee169c41729664557e463cbf83507b.jpg 48w" width="297"/></a><br/>
 <a href="https://www.youtube.com/channel/UCPUZ1hgQgIIYQeMqoJWWoXw" rel="noopener" target="_blank">Watch Stabat Mater performances</a></p>
 </div>
 </div></section>
 </div><div class="widget-area footer-widgets-2 footer-widget-area col col-xs-12 col-sm-6 col-md-3"><section class="widget widget_text" id="text-46"><div class="widget-wrap"><h3 class="widgettitle widget-title">Photos on Instagram</h3>
-<div class="textwidget"><p><a href="https://www.instagram.com/stabatmater.info/" rel="noopener" target="_blank"><img alt="" class="alignnone size-full wp-image-11498" decoding="async" height="178" loading="lazy" sizes="auto, (max-width: 297px) 100vw, 297px" src="assets/8a12126af8cd6c8514d9f3614ed3520b61583573e8cde1eacb62ee1e98e864b6.jpg" srcset="assets/8a12126af8cd6c8514d9f3614ed3520b61583573e8cde1eacb62ee1e98e864b6.jpg 297w, assets/eed9c985a6c642a7915167328ca9531d7161e0ead6f03735066f59351d30c9f3.jpg 24w, assets/6a418da7a381d78d24be3f9dbe8eeb9ec2cccf9f49b72729d1133a4425546cd7.jpg 36w, assets/3225dcf678b1d8e4f1e6d67524ada03a488395ea03b0b883d9fe103a5d1bf559.jpg 48w" width="297"/></a><br/>
+<div class="textwidget"><p><a href="https://www.instagram.com/stabatmater.info/" rel="noopener" target="_blank"><img alt="" class="alignnone size-full wp-image-11498" decoding="async" height="178" loading="lazy" sizes="auto, (max-width: 297px) 100vw, 297px" src="../assets/8a12126af8cd6c8514d9f3614ed3520b61583573e8cde1eacb62ee1e98e864b6.jpg" srcset="../assets/8a12126af8cd6c8514d9f3614ed3520b61583573e8cde1eacb62ee1e98e864b6.jpg 297w, ../assets/eed9c985a6c642a7915167328ca9531d7161e0ead6f03735066f59351d30c9f3.jpg 24w, ../assets/6a418da7a381d78d24be3f9dbe8eeb9ec2cccf9f49b72729d1133a4425546cd7.jpg 36w, ../assets/3225dcf678b1d8e4f1e6d67524ada03a488395ea03b0b883d9fe103a5d1bf559.jpg 48w" width="297"/></a><br/>
 <a href="https://www.instagram.com/stabatmater.info/" rel="noopener" target="_blank">Mary at the foot of the cross</a></p>
 </div>
 </div></section>
 </div><div class="widget-area footer-widgets-3 footer-widget-area col col-xs-12 col-sm-6 col-md-3"><section class="widget widget_text" id="text-52"><div class="widget-wrap"><h3 class="widgettitle widget-title">Stabat Mater Book</h3>
-<div class="textwidget"><p><a href="https://www.amazon.com/Stabat-Mater-Dolorosa-Journey-Centuries/dp/B0CY8T9MG1" rel="noopener" target="_blank"><img class="alignnone size-full wp-image-9160" decoding="async" src="assets/d15b955e06da74bcf5f0d0d0e0c36640bddab99463e45cd132268738cc749fd0.jpg"/> </a> <a href="https://www.amazon.com/Stabat-Mater-Dolorosa-Journey-Centuries/dp/B0CY8T9MG1">New Release: Stabat Mater Dolorosa</a></p>
+<div class="textwidget"><p><a href="https://www.amazon.com/Stabat-Mater-Dolorosa-Journey-Centuries/dp/B0CY8T9MG1" rel="noopener" target="_blank"><img class="alignnone size-full wp-image-9160" decoding="async" src="../assets/d15b955e06da74bcf5f0d0d0e0c36640bddab99463e45cd132268738cc749fd0.jpg"/> </a> <a href="https://www.amazon.com/Stabat-Mater-Dolorosa-Journey-Centuries/dp/B0CY8T9MG1">New Release: Stabat Mater Dolorosa</a></p>
 </div>
 </div></section>
 </div><div class="widget-area footer-widgets-4 footer-widget-area col col-xs-12 col-sm-6 col-md-3"><section class="widget widget_text" id="text-22"><div class="widget-wrap"><h3 class="widgettitle widget-title">Interested?</h3>
@@ -934,7 +1076,7 @@ time.uagb-post__date {
 <input type="submit" value="Sign up">
 </input></p>
 </div>
-<p><label style="display: none !important;">Leave this field empty if you&rsquo;re human: <input autocomplete="off" name="_mc4wp_honeypot" tabindex="-1" type="text" value=""/></label><input name="_mc4wp_timestamp" type="hidden" value="1755304430"><input name="_mc4wp_form_id" type="hidden" value="10075"/><input name="_mc4wp_form_element_id" type="hidden" value="mc4wp-form-1"/></input></p>
+<p><label style="display: none !important;">Leave this field empty if you&rsquo;re human: <input autocomplete="off" name="_mc4wp_honeypot" tabindex="-1" type="text" value=""/></label><input name="_mc4wp_timestamp" type="hidden" value="1755305448"><input name="_mc4wp_form_id" type="hidden" value="10075"/><input name="_mc4wp_form_element_id" type="hidden" value="mc4wp-form-1"/></input></p>
 <div class="mc4wp-response"></div>
 </form>
 <p><!-- / Mailchimp for WordPress Plugin --></p>
@@ -942,8 +1084,8 @@ time.uagb-post__date {
 </div></section>
 </div></div></div></div><footer class="site-footer text-sm"><div class="wrap"><aside class="widget-area"><h2 class="genesis-sidebar-title screen-reader-text">Site Footer</h2><section class="widget widget_text" id="text-27"><div class="widget-wrap"> <div class="textwidget"></div>
 </div></section>
-</aside><p><div class="creds"><p>&copy;&nbsp;2025  &middot; <a href="nl/copyright/index.html" target="_blank">Copyright</a> <a href="nl/privacy/index.html" target="_blank">Privacy</a>
-<a href="nl/disclaimer/index.html" target="_blank">Disclaimer</a>  &middot; Bouw: <a href="http://www.bronwasserwebsites.nl" target="_blank">Bronwasser Websites</a> in <a href="https://wordpress.org/">WordPress</a>
+</aside><p><div class="creds"><p>&copy;&nbsp;2025  &middot; <a href="../nl/copyright/index.html" target="_blank">Copyright</a> <a href="../nl/privacy/index.html" target="_blank">Privacy</a>
+<a href="../nl/disclaimer/index.html" target="_blank">Disclaimer</a>  &middot; Bouw: <a href="http://www.bronwasserwebsites.nl" target="_blank">Bronwasser Websites</a> in <a href="https://wordpress.org/">WordPress</a>
 </p></div></p></div></footer></div><script type="speculationrules">
 {"prefetch":[{"source":"document","where":{"and":[{"href_matches":"\/*"},{"not":{"href_matches":["\/wp-*.php","\/wp-admin\/*","\/wp-content\/uploads\/*","\/wp-content\/*","\/wp-content\/plugins\/*","\/wp-content\/themes\/stabatmater-2\/*","\/wp-content\/themes\/genesis\/*","\/*\\?(.+)"]}},{"not":{"selector_matches":"a[rel~=\"nofollow\"]"}},{"not":{"selector_matches":".no-prefetch, .no-prefetch a"}}]},"eagerness":"conservative"}]}
 </script>
@@ -976,36 +1118,29 @@ for (let j = 0; j < urlFields.length; j++) {
 var sbiajaxurl = "https://stabatmater.info/wp-admin/admin-ajax.php";
 
 </script>
-<style media="screen" type="text/css"></style><script> /* <![CDATA[ */var tribe_l10n_datatables = {"aria":{"sort_ascending":": activate to sort column ascending","sort_descending":": activate to sort column descending"},"length_menu":"Show _MENU_ entries","empty_table":"No data available in table","info":"Showing _START_ to _END_ of _TOTAL_ entries","info_empty":"Showing 0 to 0 of 0 entries","info_filtered":"(filtered from _MAX_ total entries)","zero_records":"No matching records found","search":"Search:","all_selected_text":"All items on this page were selected. ","select_all_link":"Select all pages","clear_selection":"Clear Selection.","pagination":{"all":"All","next":"Next","previous":"Previous"},"select":{"rows":{"0":"","_":": Selected %d rows","1":": Selected 1 row"}},"datepicker":{"dayNames":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"dayNamesShort":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"dayNamesMin":["S","M","T","W","T","F","S"],"monthNames":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthNamesShort":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthNamesMin":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"nextText":"Next","prevText":"Prev","currentText":"Today","closeText":"Done","today":"Today","clear":"Clear"}};/* ]]> */ </script>
-<div class="wpml-ls-statics-footer wpml-ls wpml-ls-legacy-list-horizontal">
-<ul><li class="wpml-ls-slot-footer wpml-ls-item wpml-ls-item-nl wpml-ls-first-item wpml-ls-last-item wpml-ls-item-legacy-list-horizontal">
-<a class="wpml-ls-link" href="nl/index.html">
-<img alt="Dutch" class="wpml-ls-flag" height="12" src="assets/bdb5ca399133d894a962b9d5d4b58618b82e6a63d5701fa5a6b40e8835a8b93f.png" width="18"/></a>
-</li></ul>
-</div>
-<script id="genesis-blocks-dismiss-js-js" src="assets/5734c669b341a17722eeae846e120e3e44648994dad0fa3d6f315b91659a8780.js" type="text/javascript"></script>
-<script id="isotope-js" src="assets/1f3e4e8b6593f2c6ec2cb62a4717e670e26d8c515c604bf7bb537c902d30ed68.js" type="text/javascript"></script>
-<script id="isotope-init-js" src="assets/4949350e934d8302f587956129b5fae6133855d01b88b837dffa333799fe8b1f.js" type="text/javascript"></script>
-<script async="async" data-wp-strategy="async" id="comment-reply-js" src="assets/834b5e0dfe39da19aec5ce200b9d514314a0bad5d723a99262f9d98b1b6ca455.js" type="text/javascript"></script>
-<script id="hoverIntent-js" src="assets/878fe22af4c0105a69cd338defaeae6b13993594d9a3d7831e098b6830d35c7c.js" type="text/javascript"></script>
-<script id="superfish-js" src="assets/c7fb28de0090b40e44c1966e05a3aee9f2fb8ffb909dac15e4da07650b57bbdb.js" type="text/javascript"></script>
-<script id="skip-links-js" src="assets/2c01acb28575394c1a4f3ce8257622be03804b92d65cbc33bfb09d7ebd88c6c3.js" type="text/javascript"></script>
+<style media="screen" type="text/css"></style><script> /* <![CDATA[ */var tribe_l10n_datatables = {"aria":{"sort_ascending":": activate to sort column ascending","sort_descending":": activate to sort column descending"},"length_menu":"Show _MENU_ entries","empty_table":"No data available in table","info":"Showing _START_ to _END_ of _TOTAL_ entries","info_empty":"Showing 0 to 0 of 0 entries","info_filtered":"(filtered from _MAX_ total entries)","zero_records":"No matching records found","search":"Search:","all_selected_text":"All items on this page were selected. ","select_all_link":"Select all pages","clear_selection":"Clear Selection.","pagination":{"all":"All","next":"Next","previous":"Previous"},"select":{"rows":{"0":"","_":": Selected %d rows","1":": Selected 1 row"}},"datepicker":{"dayNames":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"dayNamesShort":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"dayNamesMin":["S","M","T","W","T","F","S"],"monthNames":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthNamesShort":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthNamesMin":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"nextText":"Next","prevText":"Prev","currentText":"Today","closeText":"Done","today":"Today","clear":"Clear"}};/* ]]> */ </script><script id="genesis-blocks-dismiss-js-js" src="../assets/5734c669b341a17722eeae846e120e3e44648994dad0fa3d6f315b91659a8780.js" type="text/javascript"></script>
+<script id="isotope-js" src="../assets/1f3e4e8b6593f2c6ec2cb62a4717e670e26d8c515c604bf7bb537c902d30ed68.js" type="text/javascript"></script>
+<script id="isotope-init-js" src="../assets/4949350e934d8302f587956129b5fae6133855d01b88b837dffa333799fe8b1f.js" type="text/javascript"></script>
+<script async="async" data-wp-strategy="async" id="comment-reply-js" src="../assets/834b5e0dfe39da19aec5ce200b9d514314a0bad5d723a99262f9d98b1b6ca455.js" type="text/javascript"></script>
+<script id="hoverIntent-js" src="../assets/878fe22af4c0105a69cd338defaeae6b13993594d9a3d7831e098b6830d35c7c.js" type="text/javascript"></script>
+<script id="superfish-js" src="../assets/c7fb28de0090b40e44c1966e05a3aee9f2fb8ffb909dac15e4da07650b57bbdb.js" type="text/javascript"></script>
+<script id="skip-links-js" src="../assets/2c01acb28575394c1a4f3ce8257622be03804b92d65cbc33bfb09d7ebd88c6c3.js" type="text/javascript"></script>
 <script id="mai-theme-engine-js-extra" type="text/javascript">
 /* <![CDATA[ */
 var maiVars = {"mainMenu":"Menu","subMenu":"Submenu","searchBox":"<div class=\"search-box\" style=\"display:none;\"><form class=\"search-form\" method=\"get\" action=\"https:\/\/stabatmater.info\/\" role=\"search\"><label class=\"search-form-label screen-reader-text\" for=\"searchform-1\">Search this website<\/label><input class=\"search-form-input\" type=\"search\" name=\"s\" id=\"searchform-1\" placeholder=\"Search this website\"><input class=\"search-form-submit\" type=\"submit\" value=\"Search\"><meta content=\"https:\/\/stabatmater.info\/?s={s}\"><\/form><\/div>","maiScrollTo":".scroll-to"};
 /* ]]> */
 </script>
-<script id="mai-theme-engine-js" src="assets/3279c205b93d03f16d9d3b275402cbb73fe4b331983197ae9a9d1953505ad82a.js" type="text/javascript"></script>
-<script id="basic-scroll-js" src="assets/084577dddc2d54e99c6a8ba8c9f6529fbed60dc70dbeb0793b35e1e1ff133237.js" type="text/javascript"></script>
+<script id="mai-theme-engine-js" src="../assets/3279c205b93d03f16d9d3b275402cbb73fe4b331983197ae9a9d1953505ad82a.js" type="text/javascript"></script>
+<script id="basic-scroll-js" src="../assets/084577dddc2d54e99c6a8ba8c9f6529fbed60dc70dbeb0793b35e1e1ff133237.js" type="text/javascript"></script>
 <script id="mai-scroll-js-extra" type="text/javascript">
 /* <![CDATA[ */
 var maiScroll = {"logoWidth":"250","logoTop":"0","logoBottom":"0","logoShrinkWidth":"100","logoShrinkTop":"-50","logoShrinkBottom":"0"};
 /* ]]> */
 </script>
-<script id="mai-scroll-js" src="assets/73abdacd236813e10dd97578312865d366ccd646ee318015c23a0a327c7c0d53.js" type="text/javascript"></script>
-<script id="mai-responsive-videos-js" src="assets/455e3a7f053e3940e0ae79587e612cd09ac5b34aa481f7a47b7d35416f17a9ee.js" type="text/javascript"></script>
-<script id="mai-responsive-video-init-js" src="assets/3d1f94b919547af9d73c9f0684644c106745c5044ad0ab05e6966ebec61edabd.js" type="text/javascript"></script>
-<script defer="" id="mc4wp-forms-api-js" src="assets/ad1a35ca3972f0358b9df9cc4783e3f1c233a6f683bb2d70ff6dc1c22b4a1452.js" type="text/javascript"></script>
+<script id="mai-scroll-js" src="../assets/73abdacd236813e10dd97578312865d366ccd646ee318015c23a0a327c7c0d53.js" type="text/javascript"></script>
+<script id="mai-responsive-videos-js" src="../assets/455e3a7f053e3940e0ae79587e612cd09ac5b34aa481f7a47b7d35416f17a9ee.js" type="text/javascript"></script>
+<script id="mai-responsive-video-init-js" src="../assets/3d1f94b919547af9d73c9f0684644c106745c5044ad0ab05e6966ebec61edabd.js" type="text/javascript"></script>
+<script defer="" id="mc4wp-forms-api-js" src="../assets/ad1a35ca3972f0358b9df9cc4783e3f1c233a6f683bb2d70ff6dc1c22b4a1452.js" type="text/javascript"></script>
 <script id="slb_context" type="text/javascript">/* <![CDATA[ */if ( !!window.jQuery ) {(function($){$(document).ready(function(){if ( !!window.SLB ) { {$.extend(SLB, {"context":["public","user_guest"]});} }})})(jQuery);}/* ]]> */</script>
 <!-- Cookie Notice plugin v2.5.7 by Hu-manity.co https://hu-manity.co/ -->
 <div aria-label="Cookie Notice" class="cookie-notice-hidden cookie-revoke-hidden cn-position-bottom" id="cookie-notice" role="dialog" style="background-color: rgba(50,50,58,1);"><div class="cookie-notice-container" style="color: #fff"><span class="cn-text-container" id="cn-notice-text">We use cookies to ensure that we give you the best experience on our website. If you continue to use this site we will assume that you are happy with it.</span><span class="cn-buttons-container" id="cn-notice-buttons"><button aria-label="Ok" class="cn-set-cookie cn-button" data-cookie-set="accept" id="cn-accept-cookie" style="background-color: #00a99d">Ok</button></span><span class="cn-close-icon" data-cookie-set="accept" id="cn-close-notice" title="No"></span></div>


### PR DESCRIPTION
## Summary
- add a donations downtime article that mirrors the site layout and includes updated metadata, imagery, and publish date
- update the home page recent posts widget so the top entry links to the new article and reflects the new date

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68d157591e948333b5876f5d6db76747