### PR TITLE
Improve GitHub Pages link fallback

### DIFF
--- a/_includes/utils/url.html
+++ b/_includes/utils/url.html
@@ -18,6 +18,25 @@
   {% else %}
     {% assign preferred_root = include.base %}
   {% endcase %}
+  {% assign preferred_root = preferred_root | default: site.baseurl %}
+  {% assign github = site.github %}
+  {% if (preferred_root == '' or preferred_root == nil) and github %}
+    {% assign github_base = github.baseurl %}
+    {% if github_base and github_base != '' %}
+      {% assign preferred_root = github_base %}
+    {% elsif github.is_project_page %}
+      {% assign repo_name = github.repository_name %}
+      {% if repo_name == '' or repo_name == nil %}
+        {% assign repo_nwo = github.repository_nwo | default: site.repository %}
+        {% if repo_nwo and repo_nwo != '' %}
+          {% assign repo_name = repo_nwo | split: '/' | last %}
+        {% endif %}
+      {% endif %}
+      {% if repo_name and repo_name != '' %}
+        {% assign preferred_root = '/' | append: repo_name %}
+      {% endif %}
+    {% endif %}
+  {% endif %}
   {% if preferred_root and preferred_root != '' %}
     {% assign trimmed = preferred_root | strip %}
     {% assign last_char = trimmed | slice: -1, 1 %}


### PR DESCRIPTION
## Summary
- extend the shared URL helper to reuse GitHub metadata for project pages when no base path is configured
- derive the repository name as a final fallback so navigation links resolve under the project slug on GitHub Pages

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68d5b686944c8333a64fa05c28e25151