### PR TITLE
Enable GitHub metadata plugin for URL helpers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -83,3 +83,4 @@ defaults:
 plugins:
   - jekyll-feed
   - jekyll-sitemap
+  - jekyll-github-metadata


### PR DESCRIPTION
## Summary
- register the `jekyll-github-metadata` plugin so Liquid helpers can resolve GitHub Pages base URLs

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68d5c780aba48333b290f23237ef4fbb